### PR TITLE
fix psbt test. and fix bug of building nested derivation path

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.1
-erlang 21.3.3
+elixir 1.9.4-otp-22
+erlang 22.0.7

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -188,7 +188,8 @@ defmodule Bitcoinex.PSBT.In do
   @psbt_in_proprietary 0xFC
 
   def parse_inputs(psbt, num_inputs) do
-    parse_input(psbt, [], num_inputs)
+    psbt
+    |> parse_input([], num_inputs)
   end
 
   defp parse_input(psbt, inputs, 0), do: {Enum.reverse(inputs), psbt}
@@ -199,6 +200,15 @@ defmodule Bitcoinex.PSBT.In do
         parse_input(psbt, inputs, num_inputs - 1)
 
       {input, psbt} ->
+        input =
+          case input do
+            %{bip32_derivation: bip32_derivation} when is_list(bip32_derivation) ->
+              %{input | bip32_derivation: Enum.reverse(bip32_derivation)}
+
+            _ ->
+              input
+          end
+
         parse_input(psbt, [input | inputs], num_inputs - 1)
     end
   end
@@ -255,18 +265,20 @@ defmodule Bitcoinex.PSBT.In do
     bip32_derivation =
       case input.bip32_derivation do
         nil ->
-          %{
-            public_key: Base.encode16(public_key, case: :lower),
-            derivation: Base.encode16(value, case: :lower)
-          }
+          [
+            %{
+              public_key: Base.encode16(public_key, case: :lower),
+              derivation: Base.encode16(value, case: :lower)
+            }
+          ]
 
         _ ->
           [
-            input.bip32_derivation
-            | %{
-                public_key: Base.encode16(public_key, case: :lower),
-                derivation: Base.encode16(value, case: :lower)
-              }
+            %{
+              public_key: Base.encode16(public_key, case: :lower),
+              derivation: Base.encode16(value, case: :lower)
+            }
+            | input.bip32_derivation
           ]
       end
 
@@ -331,6 +343,15 @@ defmodule Bitcoinex.PSBT.Out do
         parse_output(psbt, outputs, num_outputs - 1)
 
       {output, psbt} ->
+        output =
+          case output do
+            %{bip32_derivation: bip32_derivation} when is_list(bip32_derivation) ->
+              %{output | bip32_derivation: Enum.reverse(bip32_derivation)}
+
+            _ ->
+              output
+          end
+
         parse_output(psbt, [output | outputs], num_outputs - 1)
     end
   end
@@ -357,18 +378,20 @@ defmodule Bitcoinex.PSBT.Out do
     bip32_derivation =
       case output.bip32_derivation do
         nil ->
-          %{
-            public_key: Base.encode16(public_key, case: :lower),
-            derivation: Base.encode16(value, case: :lower)
-          }
+          [
+            %{
+              public_key: Base.encode16(public_key, case: :lower),
+              derivation: Base.encode16(value, case: :lower)
+            }
+          ]
 
         _ ->
           [
-            output.bip32_derivation
-            | %{
-                public_key: Base.encode16(public_key, case: :lower),
-                derivation: Base.encode16(value, case: :lower)
-              }
+            %{
+              public_key: Base.encode16(public_key, case: :lower),
+              derivation: Base.encode16(value, case: :lower)
+            }
+            | output.bip32_derivation
           ]
       end
 

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "libsecp256k1": {:git, "https://github.com/AltoFinancial/libsecp256k1.git", "c2e4363ff69008ed99f1fa3befd4d7e72919397b", [branch: "add-spec"]},
+  "libsecp256k1": {:git, "https://github.com/RiverFinancial/libsecp256k1.git", "c2e4363ff69008ed99f1fa3befd4d7e72919397b", [branch: "add-spec"]},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.9.0", "c72132a6071261893518fa08e121e911c9358713f62794a90c95db59042af375", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/psbt_test.exs
+++ b/test/psbt_test.exs
@@ -188,11 +188,11 @@ defmodule Bitcoinex.PSBTTest do
             %{
               derivation: "d90c6a4fae0000800000008000000000",
               public_key: "029da12cdb5b235692b91536afefe5c91c3ab9473d8e43b533836ab456299c8871"
+            },
+            %{
+              derivation: "d90c6a4fae0000800100008000000000",
+              public_key: "03372b34234ed7cf9c1fea5d05d441557927be9542b162eb02e1ab2ce80224c00b"
             }
-            | %{
-                derivation: "d90c6a4fae0000800100008000000000",
-                public_key: "03372b34234ed7cf9c1fea5d05d441557927be9542b162eb02e1ab2ce80224c00b"
-              }
           ],
           final_scriptsig: nil,
           final_scriptwitness: nil,
@@ -258,11 +258,11 @@ defmodule Bitcoinex.PSBTTest do
             %{
               derivation: "b4a6ba67000000800000008004000080",
               public_key: "03b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd46"
+            },
+            %{
+              derivation: "b4a6ba67000000800000008005000080",
+              public_key: "03de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd"
             }
-            | %{
-                derivation: "b4a6ba67000000800000008005000080",
-                public_key: "03de55d1e1dac805e3f8a58c1fbf9b94c02f3dbaafe127fefca4995f26f82083bd"
-              }
           ],
           final_scriptsig: nil,
           final_scriptwitness: nil,
@@ -325,7 +325,7 @@ defmodule Bitcoinex.PSBTTest do
         version: nil,
         xpub: nil
       },
-      expected_inputs: [
+      expected_in: [
         %Bitcoinex.PSBT.In{
           bip32_derivation: nil,
           final_scriptsig: nil,
@@ -375,23 +375,21 @@ defmodule Bitcoinex.PSBTTest do
           }
         }
       ],
-      expected_outputs: [
+      expected_out: [
         %Bitcoinex.PSBT.Out{
           bip32_derivation: [
-            [
-              %{
-                derivation: "000000000000008002000080020000000000000000000000010000000d000000",
-                public_key: "023e1a92f74483a4c12a196d6c0253ac589cfadd5964ff3e6c63aef5d577051ed4"
-              }
-              | %{
-                  derivation: "000000000000008002000080020000000000000000000000010000000d000000",
-                  public_key: "024d0e39b33ab57782a98fd06a7d0653385e509ee3b74dc45559e6db6391d31378"
-                }
-            ]
-            | %{
-                derivation: "000000000000008002000080020000000000000000000000010000000d000000",
-                public_key: "036c0bae6bcb02e47c857c480ed1d23888c8ad6a66b83ab111cb6b9242afb1c725"
-              }
+            %{
+              derivation: "000000000000008002000080020000000000000000000000010000000d000000",
+              public_key: "023e1a92f74483a4c12a196d6c0253ac589cfadd5964ff3e6c63aef5d577051ed4"
+            },
+            %{
+              derivation: "000000000000008002000080020000000000000000000000010000000d000000",
+              public_key: "024d0e39b33ab57782a98fd06a7d0653385e509ee3b74dc45559e6db6391d31378"
+            },
+            %{
+              derivation: "000000000000008002000080020000000000000000000000010000000d000000",
+              public_key: "036c0bae6bcb02e47c857c480ed1d23888c8ad6a66b83ab111cb6b9242afb1c725"
+            }
           ],
           proprietary: nil,
           redeem_script: nil,


### PR DESCRIPTION
I fixed some failed test in local. bip32_derivation should be a 1 level list but previously it's constructed as a nested list.

I ran `mix test` and `mix lint.all` in local and they all pass