### PR TITLE
rename Bitcoin.LighningNetwork to Bitcoinex.LightningNetwork. fix typ…

### DIFF
--- a/lib/lightning_network/lightning_network.ex
+++ b/lib/lightning_network/lightning_network.ex
@@ -1,6 +1,6 @@
-defmodule Bitcoin.LightningNetwork do
+defmodule Bitcoinex.LightningNetwork do
   alias Bitcoinex.LightningNetwork.Invoice
 
   # defdelegate encode_invoice(invoice), to: Invoice, as: :encode
-  defdelegate encode_decode(invoice), to: Invoice, as: :decode
+  defdelegate decode_invoice(invoice), to: Invoice, as: :decode
 end


### PR DESCRIPTION
fix module name from ~`Bitcoin.LightningNetwork`~ to `Bitcoinex.LightningNetwork`

and fix typo of function name `encode_decode` to `decode_invoice`