### PR TITLE
Add decode_type method to BitcoinEx.Address

### DIFF
--- a/lib/address.ex
+++ b/lib/address.ex
@@ -39,11 +39,31 @@ defmodule Bitcoinex.Address do
     is_valid_base58_check_address?(address, network.p2sh_version_decimal_prefix)
   end
 
-  def is_valid?(address, network_name, address_type) when address_type in [:p2wpkh, :p2wsh] do
+  def is_valid?(address, network_name, :p2wpkh) do
     case Segwit.decode_address(address) do
-      {:ok, {^network_name, _, _}} ->
-        true
+      {:ok, {^network_name, witness_version, witness_program}} ->
+        if witness_version == 0 and length(witness_program) == 20 do
+            true
+        else
+            false
+        end
+      # network is not same as network set in config
+      {:ok, {_network_name, _, _}} ->
+        false
 
+      {:error, _error} ->
+        false
+    end
+  end
+
+  def is_valid?(address, network_name, :p2wsh) do
+    case Segwit.decode_address(address) do
+      {:ok, {^network_name, witness_version, witness_program}} ->
+        if witness_version == 0 and length(witness_program) == 32 do
+            true
+        else
+            false
+        end
       # network is not same as network set in config
       {:ok, {_network_name, _, _}} ->
         false
@@ -64,6 +84,15 @@ defmodule Bitcoinex.Address do
 
       _ ->
         false
+    end
+  end
+
+  @spec decode_type(String.t(), Bitcoinex.Network.network_name()) ::
+          {:ok, address_type} | {:error, term()}
+  def decode_type(address, network_name) do
+    case Enum.find(@address_type, &is_valid?(address, network_name, &1)) do
+      nil -> {:error, :decode_error}
+      type -> {:ok, type}
     end
   end
 end

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -6,7 +6,7 @@ defmodule Bitcoinex.Address do
   """
   alias Bitcoinex.{Segwit, Base58Check, Network}
   @type address_type :: :p2pkh | :p2sh | :p2wpkh | :p2wsh
-  @address_type ~w(p2pkh p2sh p2wpkh p2wsh)a
+  @address_types ~w(p2pkh p2sh p2wpkh p2wsh)a
 
   # TODO: write tests
   def encode(pubkey, network_name, :p2pkh) do
@@ -25,7 +25,7 @@ defmodule Bitcoinex.Address do
 
   @spec is_valid?(String.t(), Bitcoinex.Network.network_name()) :: boolean
   def is_valid?(address, network_name) do
-    Enum.any?(@address_type, &is_valid?(address, network_name, &1))
+    Enum.any?(@address_types, &is_valid?(address, network_name, &1))
   end
 
   @spec is_valid?(String.t(), Bitcoinex.Network.network_name(), address_type) :: boolean
@@ -74,7 +74,7 @@ defmodule Bitcoinex.Address do
   end
 
   def supported_address_types() do
-    @address_type
+    @address_types
   end
 
   defp is_valid_base58_check_address?(address, valid_prefix) do
@@ -90,7 +90,7 @@ defmodule Bitcoinex.Address do
   @spec decode_type(String.t(), Bitcoinex.Network.network_name()) ::
           {:ok, address_type} | {:error, term()}
   def decode_type(address, network_name) do
-    case Enum.find(@address_type, &is_valid?(address, network_name, &1)) do
+    case Enum.find(@address_types, &is_valid?(address, network_name, &1)) do
       nil -> {:error, :decode_error}
       type -> {:ok, type}
     end

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -41,12 +41,8 @@ defmodule Bitcoinex.Address do
 
   def is_valid?(address, network_name, :p2wpkh) do
     case Segwit.decode_address(address) do
-      {:ok, {^network_name, witness_version, witness_program}} ->
-        if witness_version == 0 and length(witness_program) == 20 do
-            true
-        else
-            false
-        end
+      {:ok, {^network_name, witness_version, witness_program}} when witness_version == 0 and length(witness_program) == 20 ->
+        true
       # network is not same as network set in config
       {:ok, {_network_name, _, _}} ->
         false
@@ -58,12 +54,8 @@ defmodule Bitcoinex.Address do
 
   def is_valid?(address, network_name, :p2wsh) do
     case Segwit.decode_address(address) do
-      {:ok, {^network_name, witness_version, witness_program}} ->
-        if witness_version == 0 and length(witness_program) == 32 do
-            true
-        else
-            false
-        end
+      {:ok, {^network_name, witness_version, witness_program}} when witness_version == 0 and length(witness_program) == 32 ->
+        true
       # network is not same as network set in config
       {:ok, {_network_name, _, _}} ->
         false
@@ -88,7 +80,7 @@ defmodule Bitcoinex.Address do
   end
 
   @spec decode_type(String.t(), Bitcoinex.Network.network_name()) ::
-          {:ok, address_type} | {:error, term()}
+          {:ok, address_type} | {:error, :decode_error}
   def decode_type(address, network_name) do
     case Enum.find(@address_types, &is_valid?(address, network_name, &1)) do
       nil -> {:error, :decode_error}

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -28,9 +28,6 @@ defmodule Bitcoinex.AddressTest do
 
       valid_mainnet_segwit_addresses = [
         "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
-        "BC1SW50QA3JX3S",
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj"
       ]
 
       valid_testnet_segwit_addresses = [
@@ -43,19 +40,44 @@ defmodule Bitcoinex.AddressTest do
         "bcrt1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvseswlauz7"
       ]
 
+      valid_mainnet_p2wpkh_addresses = [
+        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      ]
+
+      valid_testnet_p2wpkh_addresses = [
+        "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+      ]
+
+      valid_mainnet_p2wsh_addresses = [
+        "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+      ]
+
+      valid_testnet_p2wsh_addresses = [
+        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
+      ]
+
       valid_mainnet_addresses =
         valid_mainnet_p2pkh_addresses ++
-          valid_mainnet_p2sh_addresses ++ valid_mainnet_segwit_addresses
+          valid_mainnet_p2sh_addresses ++ 
+            valid_mainnet_segwit_addresses ++
+              valid_mainnet_p2wpkh_addresses ++
+                valid_mainnet_p2wsh_addresses
 
       valid_testnet_addresses =
         valid_testnet_p2pkh_addresses ++
-          valid_testnet_p2sh_addresses ++ valid_testnet_segwit_addresses
+          valid_testnet_p2sh_addresses ++ 
+            valid_testnet_segwit_addresses ++
+              valid_testnet_p2wpkh_addresses ++
+                valid_testnet_p2wsh_addresses
 
       valid_regtest_addresses =
         valid_testnet_p2pkh_addresses ++
           valid_testnet_p2sh_addresses ++ valid_regtest_segwit_addresses
 
       invalid_addresses = [
+        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", # witness v1 address
+        "BC1SW50QA3JX3S",
+        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
         "",
         "rrRmhfXzGBKbV4YHtbpxfA1ftEcry8AJaX",
         "LSxNsEQekEpXMS4B7tUYstMEdMyH321ZQ1",
@@ -83,6 +105,10 @@ defmodule Bitcoinex.AddressTest do
        valid_mainnet_segwit_addresses: valid_mainnet_segwit_addresses,
        valid_testnet_segwit_addresses: valid_testnet_segwit_addresses,
        valid_regtest_segwit_addresses: valid_regtest_segwit_addresses,
+       valid_mainnet_p2wpkh_addresses: valid_mainnet_p2wpkh_addresses,
+       valid_testnet_p2wpkh_addresses: valid_testnet_p2wpkh_addresses,
+       valid_mainnet_p2wsh_addresses: valid_mainnet_p2wsh_addresses,
+       valid_testnet_p2wsh_addresses: valid_testnet_p2wsh_addresses,
        invalid_addresses: invalid_addresses}
     end
 
@@ -128,6 +154,49 @@ defmodule Bitcoinex.AddressTest do
             refute Address.is_valid?(invalid_address, network_name, address_type)
           end
         end
+      end
+    end
+
+    test "check that the address decodes to the correct address type", %{
+      valid_mainnet_p2pkh_addresses: valid_mainnet_p2pkh_addresses,
+      valid_testnet_p2pkh_addresses: valid_testnet_p2pkh_addresses,
+      valid_mainnet_p2sh_addresses: valid_mainnet_p2sh_addresses,
+      valid_testnet_p2sh_addresses: valid_testnet_p2sh_addresses,
+      valid_mainnet_p2wpkh_addresses: valid_mainnet_p2wpkh_addresses,
+      valid_testnet_p2wpkh_addresses: valid_testnet_p2wpkh_addresses,
+      valid_mainnet_p2wsh_addresses: valid_mainnet_p2wsh_addresses,
+      valid_testnet_p2wsh_addresses: valid_testnet_p2wsh_addresses
+    } do
+      for mainnet_p2pkh <- valid_mainnet_p2pkh_addresses do
+        assert Address.decode_type(mainnet_p2pkh, :mainnet) == {:ok, :p2pkh}
+      end
+
+      for testnet_p2pkh <- valid_testnet_p2pkh_addresses do
+        assert Address.decode_type(testnet_p2pkh, :testnet) == {:ok, :p2pkh}
+      end
+
+      for mainnet_p2sh <- valid_mainnet_p2sh_addresses do
+        assert Address.decode_type(mainnet_p2sh, :mainnet) == {:ok, :p2sh}
+      end
+
+      for testnet_p2sh <- valid_testnet_p2sh_addresses do
+        assert Address.decode_type(testnet_p2sh, :testnet) == {:ok, :p2sh}
+      end
+
+      for mainnet_p2wpkh <- valid_mainnet_p2wpkh_addresses do
+        assert Address.decode_type(mainnet_p2wpkh, :mainnet) == {:ok, :p2wpkh}
+      end
+
+      for testnet_p2wpkh <- valid_testnet_p2wpkh_addresses do
+        assert Address.decode_type(testnet_p2wpkh, :testnet) == {:ok, :p2wpkh}
+      end
+
+      for mainnet_p2wsh <- valid_mainnet_p2wsh_addresses do
+        assert Address.decode_type(mainnet_p2wsh, :mainnet) == {:ok, :p2wsh}
+      end
+
+      for testnet_p2wsh <- valid_testnet_p2wsh_addresses do
+        assert Address.decode_type(testnet_p2wsh, :testnet) == {:ok, :p2wsh}
       end
     end
   end


### PR DESCRIPTION
Adds a decode_type method to BitcoinEx.Address in order to return the type of address. 

Split the current is_valid?() method in BitcoinEx.Address for segwit addresses into two methods and add a guard to check for witness program length.

We previously were returning is_valid true for segwit addresses that are not infact valid for mainnet because they were v1 segwit addresses. Think we should return false for for v1 segwit addresses.
