### PR TITLE
change Utils.sha256 and Utils.double_sha256 input type to iodata

### DIFF
--- a/lib/address.ex
+++ b/lib/address.ex
@@ -41,8 +41,10 @@ defmodule Bitcoinex.Address do
 
   def is_valid?(address, network_name, :p2wpkh) do
     case Segwit.decode_address(address) do
-      {:ok, {^network_name, witness_version, witness_program}} when witness_version == 0 and length(witness_program) == 20 ->
+      {:ok, {^network_name, witness_version, witness_program}}
+      when witness_version == 0 and length(witness_program) == 20 ->
         true
+
       # network is not same as network set in config
       {:ok, {_network_name, _, _}} ->
         false
@@ -54,8 +56,10 @@ defmodule Bitcoinex.Address do
 
   def is_valid?(address, network_name, :p2wsh) do
     case Segwit.decode_address(address) do
-      {:ok, {^network_name, witness_version, witness_program}} when witness_version == 0 and length(witness_program) == 32 ->
+      {:ok, {^network_name, witness_version, witness_program}}
+      when witness_version == 0 and length(witness_program) == 32 ->
         true
+
       # network is not same as network set in config
       {:ok, {_network_name, _, _}} ->
         false

--- a/lib/base58_check.ex
+++ b/lib/base58_check.ex
@@ -61,7 +61,7 @@ defmodule Bitcoinex.Base58Check do
       |> Tuple.to_list()
       |> Enum.map(&:binary.list_to_bin(&1))
 
-    case checksum == binary_slice(Utils.bin_double_sha256(decoded_body), 0..3) do
+    case checksum == binary_slice(Utils.double_sha256(decoded_body), 0..3) do
       false -> {:error, :invalid_checksum}
       true -> {:ok, decoded_body}
     end
@@ -110,7 +110,7 @@ defmodule Bitcoinex.Base58Check do
   @spec checksum(binary) :: binary
   defp checksum(body) do
     body
-    |> Utils.bin_double_sha256()
+    |> Utils.double_sha256()
     |> binary_slice(0..3)
   end
 

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -25,7 +25,7 @@ defmodule Bitcoinex.Transaction do
 
     Base.encode16(
       <<:binary.decode_unsigned(
-          Utils.bin_double_sha256(legacy_txn),
+          Utils.double_sha256(legacy_txn),
           :big
         )::little-size(256)>>,
       case: :lower

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,5 +1,5 @@
 defmodule Bitcoinex.Utils do
-  @spec sha256(list(integer)) :: binary
+  @spec sha256(iodata()) :: binary
   def sha256(str) do
     :crypto.hash(:sha256, str)
   end
@@ -13,8 +13,8 @@ defmodule Bitcoinex.Utils do
     for _ <- 1..num, do: x
   end
 
-  @spec bin_double_sha256(binary) :: binary
-  def bin_double_sha256(preimage) do
+  @spec double_sha256(iodata()) :: binary
+  def double_sha256(preimage) do
     :crypto.hash(
       :sha256,
       :crypto.hash(:sha256, preimage)

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -27,7 +27,7 @@ defmodule Bitcoinex.AddressTest do
       ]
 
       valid_mainnet_segwit_addresses = [
-        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
+        "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4"
       ]
 
       valid_testnet_segwit_addresses = [
@@ -41,7 +41,7 @@ defmodule Bitcoinex.AddressTest do
       ]
 
       valid_mainnet_p2wpkh_addresses = [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
       ]
 
       valid_testnet_p2wpkh_addresses = [
@@ -58,24 +58,25 @@ defmodule Bitcoinex.AddressTest do
 
       valid_mainnet_addresses =
         valid_mainnet_p2pkh_addresses ++
-          valid_mainnet_p2sh_addresses ++ 
-            valid_mainnet_segwit_addresses ++
-              valid_mainnet_p2wpkh_addresses ++
-                valid_mainnet_p2wsh_addresses
+          valid_mainnet_p2sh_addresses ++
+          valid_mainnet_segwit_addresses ++
+          valid_mainnet_p2wpkh_addresses ++
+          valid_mainnet_p2wsh_addresses
 
       valid_testnet_addresses =
         valid_testnet_p2pkh_addresses ++
-          valid_testnet_p2sh_addresses ++ 
-            valid_testnet_segwit_addresses ++
-              valid_testnet_p2wpkh_addresses ++
-                valid_testnet_p2wsh_addresses
+          valid_testnet_p2sh_addresses ++
+          valid_testnet_segwit_addresses ++
+          valid_testnet_p2wpkh_addresses ++
+          valid_testnet_p2wsh_addresses
 
       valid_regtest_addresses =
         valid_testnet_p2pkh_addresses ++
           valid_testnet_p2sh_addresses ++ valid_regtest_segwit_addresses
 
       invalid_addresses = [
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", # witness v1 address
+        # witness v1 address
+        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
         "BC1SW50QA3JX3S",
         "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
         "",


### PR DESCRIPTION
:crypto.hash already support iodata. So we should change `Utils.sha256` and `Utils.double_sha256 `(renamed it from `Utils.bin_double_sha256`) to iodata which is more flexible than just binary so it can also accept like `charlist`, `iolist`.

I have also run `mix format` in local. We should integrate Github action to add lint and test to CI .