### PR TITLE
Add additional documentation

### DIFF
--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -1,10 +1,15 @@
-defmodule Bitcoinex.Base58Check do
+defmodule BitcoinEx.Base58 do
   @moduledoc """
-    Some code inspired by:
+    Includes Base58 serialization and validation.
+
+    Some code is inspired by:
     https://github.com/comboy/bitcoin-elixir/blob/develop/lib/bitcoin/base58_check.ex
   """
   alias Bitcoinex.Utils
 
+  @typedoc """
+    Base58 encoding is only supported for p2sh and p2pkh address types.  
+  """
   @type address_type :: :p2sh | :p2pkh
   @base58_encode_list ~c(123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz)
   @base58_decode_map @base58_encode_list |> Enum.with_index() |> Enum.into(%{})
@@ -13,7 +18,7 @@ defmodule Bitcoinex.Base58Check do
   @type byte_list :: list(byte())
 
   @doc """
-    Decode a base58 check encoded string into a byte array and validate checksum
+    Decodes a Base58 encoded string into a byte array and validates checksum.
   """
   @spec decode(binary) :: {:ok, binary} | {:error, atom}
   def decode(binary)
@@ -31,7 +36,7 @@ defmodule Bitcoinex.Base58Check do
   end
 
   @doc """
-    Decode a base58 encoded string into a byte array
+    Decodes a Base58 encoded string into a byte array.
   """
   @spec decode_base!(binary) :: binary
   def decode_base!(binary)
@@ -52,6 +57,9 @@ defmodule Bitcoinex.Base58Check do
     |> :binary.encode_unsigned()
   end
 
+  @doc """
+    Validates a Base58 checksum.
+  """
   @spec validate_checksum(binary) :: {:ok, binary} | {:error, atom}
   def validate_checksum(data) do
     [decoded_body, checksum] =
@@ -73,7 +81,7 @@ defmodule Bitcoinex.Base58Check do
     do: char in @base58_encode_list && valid_charset?(string)
 
   @doc """
-    Encode a binary into a base58check encoded string
+    Encodes binary into a Base58 encoded string.
   """
   @spec encode(binary) :: String.t()
   def encode(bin) do
@@ -92,7 +100,7 @@ defmodule Bitcoinex.Base58Check do
   end
 
   @doc """
-    Encode a binary into a base58 encoded string
+    Encodes a binary into a Base58 encoded string.
   """
   def encode_base(bin) do
     bin

--- a/lib/base58.ex
+++ b/lib/base58.ex
@@ -1,4 +1,4 @@
-defmodule BitcoinEx.Base58 do
+defmodule Bitcoinex.Base58 do
   @moduledoc """
     Includes Base58 serialization and validation.
 

--- a/lib/bech32.ex
+++ b/lib/bech32.ex
@@ -1,6 +1,8 @@
 defmodule Bitcoinex.Bech32 do
   @moduledoc """
-  https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
+  Includes Bech32 serialization and validation.
+
+  Reference: https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32
   """
 
   use Bitwise

--- a/lib/bitcoinex.ex
+++ b/lib/bitcoinex.ex
@@ -1,18 +1,7 @@
 defmodule Bitcoinex do
   @moduledoc """
   Documentation for Bitcoinex.
+
+  BitcoinEx is an Elixir library supporting basic Bitcoin functionality.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Bitcoinex.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/lib/bitcoinex.ex
+++ b/lib/bitcoinex.ex
@@ -2,6 +2,6 @@ defmodule Bitcoinex do
   @moduledoc """
   Documentation for Bitcoinex.
 
-  BitcoinEx is an Elixir library supporting basic Bitcoin functionality.
+  Bitcoinex is an Elixir library supporting basic Bitcoin functionality.
   """
 end

--- a/lib/lightning_network/hop_hint.ex
+++ b/lib/lightning_network/hop_hint.ex
@@ -1,4 +1,10 @@
 defmodule Bitcoinex.LightningNetwork.HopHint do
+  @moduledoc """
+   A hop hint is used to help the payer route a payment to the receiver.
+
+   A hint is included in BOLT#11 Invoices.
+  """
+
   @enforce_keys [
     :node_id,
     :channel_id,

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -1,4 +1,10 @@
 defmodule Bitcoinex.LightningNetwork.Invoice do
+  @moduledoc """
+  Includes BOLT#11 Invoice serialization.
+
+  Reference: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
+  """
+
   alias Bitcoinex.{Bech32, Network, Segwit}
   alias Bitcoinex.LightningNetwork.HopHint
   alias Decimal, as: D
@@ -51,6 +57,9 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   @hop_hint_length 51
   @type error :: atom
 
+  @doc """
+   Decode accepts a Bech32 encoded string invoice and deserializes it.
+  """
   @spec decode(String.t()) :: {:ok, t} | {:error, error}
   def decode(invoice) when is_binary(invoice) do
     with {:ok, {hrp, data}} <- Bech32.decode(invoice, :infinity),
@@ -84,6 +93,9 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     {:error, :no_ln_prefix}
   end
 
+  @doc """
+   Returns the expiry of the invoice.
+  """
   @spec expires_at(Bitcoinex.LightningNetwork.Invoice.t()) :: DateTime.t()
   def expires_at(%__MODULE__{} = invoice) do
     expiry = invoice.expiry
@@ -329,7 +341,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     end
   end
 
-  def parse_expiry(data) do
+  defp parse_expiry(data) do
     base32_to_integer(data)
   end
 
@@ -626,11 +638,11 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   end
 
   @spec split_at(Enum.t(), integer()) :: {list(Enum.t()), list(Enum.t())}
-  def split_at(xs, index) when index >= 0 do
+  defp split_at(xs, index) when index >= 0 do
     {Enum.take(xs, index), Enum.drop(xs, index)}
   end
 
-  def split_at(xs, index) when index < 0 do
+  defp split_at(xs, index) when index < 0 do
     {Enum.drop(xs, index), Enum.take(xs, index)}
   end
 end

--- a/lib/lightning_network/lightning_network.ex
+++ b/lib/lightning_network/lightning_network.ex
@@ -1,4 +1,8 @@
 defmodule Bitcoinex.LightningNetwork do
+  @moduledoc """
+    Includes serialization and validation for Lightning Network BOLT#11 invoices.
+  """
+
   alias Bitcoinex.LightningNetwork.Invoice
 
   # defdelegate encode_invoice(invoice), to: Invoice, as: :encode

--- a/lib/network.ex
+++ b/lib/network.ex
@@ -1,4 +1,10 @@
 defmodule Bitcoinex.Network do
+   @moduledoc """
+    Includes network-specific paramater options.
+
+    Supported networks include mainnet, testnet3, and regtest.
+  """
+
   @enforce_keys [
     :name,
     :hrp_segwit_prefix,
@@ -21,6 +27,9 @@ defmodule Bitcoinex.Network do
 
   @type network_name :: :mainnet | :testnet | :regtest
 
+  @doc """
+    Returns a list of supported networks.
+  """
   def supported_networks() do
     [
       mainnet(),

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -1,14 +1,16 @@
 defmodule Bitcoinex.PSBT do
   @moduledoc """
-  Partially signed bitcoin transaction.
-  The format consists of key-value maps. Each map consists of a sequence of key-value records, terminated by a 0x00 byte.
+  Support for Partially Signed Bitcoin Transactions (PSBT).
+
+  The format consists of key-value maps.
+  Each map consists of a sequence of key-value records, terminated by a 0x00 byte.
+
+  Reference: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
   """
   alias Bitcoinex.PSBT
   alias Bitcoinex.PSBT.Global
   alias Bitcoinex.PSBT.In
   alias Bitcoinex.PSBT.Out
-
-  require Logger
 
   defstruct [
     :global,
@@ -21,6 +23,9 @@ defmodule Bitcoinex.PSBT do
 
   def separator, do: @separator
 
+  @doc """
+  Decodes a base64 encoded string into a PSBT.
+  """
   @spec decode(String.t()) :: {:ok, %Bitcoinex.PSBT{}} | {:error, term()}
   def decode(psbt_b64) when is_binary(psbt_b64) do
     case Base.decode64(psbt_b64, case: :lower) do
@@ -53,6 +58,9 @@ defmodule Bitcoinex.PSBT do
 end
 
 defmodule Bitcoinex.PSBT.Utils do
+  @moduledoc """
+  Contains utility functions used throughout PSBT serialization.
+  """
   alias Bitcoinex.Transaction.Utils, as: TxUtils
 
   def parse_compact_size_value(key_value) do
@@ -85,14 +93,11 @@ defmodule Bitcoinex.PSBT.Global do
   @moduledoc """
   Global properties of a partially signed bitcoin transaction.
   """
-  # alias Bitcoinex.PSBT
   alias Bitcoinex.PSBT.Global
   alias Bitcoinex.Transaction
   alias Bitcoinex.Transaction.Utils, as: TxUtils
   alias Bitcoinex.PSBT.Utils, as: PsbtUtils
-  alias Bitcoinex.Base58Check
-
-  require Logger
+  alias BitcoinEx.Base58
 
   defstruct [
     :unsigned_tx,
@@ -130,7 +135,7 @@ defmodule Bitcoinex.PSBT.Global do
 
     global = %Global{
       global
-      | xpub: %{xpub: Base58Check.encode(xpub), derivation: Base.encode16(value, case: :lower)}
+      | xpub: %{xpub: Base58.encode(xpub), derivation: Base.encode16(value, case: :lower)}
     }
 
     {global, psbt}
@@ -158,8 +163,6 @@ defmodule Bitcoinex.PSBT.In do
   alias Bitcoinex.Transaction.Out
   alias Bitcoinex.PSBT.In
   alias Bitcoinex.PSBT.Utils, as: PsbtUtils
-
-  require Logger
 
   defstruct [
     :non_witness_utxo,

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -97,7 +97,7 @@ defmodule Bitcoinex.PSBT.Global do
   alias Bitcoinex.Transaction
   alias Bitcoinex.Transaction.Utils, as: TxUtils
   alias Bitcoinex.PSBT.Utils, as: PsbtUtils
-  alias BitcoinEx.Base58
+  alias Bitcoinex.Base58
 
   defstruct [
     :unsigned_tx,

--- a/lib/segwit.ex
+++ b/lib/segwit.ex
@@ -1,9 +1,8 @@
 defmodule Bitcoinex.Segwit do
   @moduledoc """
-  Decode and Encode segwit address
+  SegWit address serialization.
   """
 
-  # TODO Alex Review
   alias Bitcoinex.Bech32
 
   use Bitwise
@@ -22,6 +21,9 @@ defmodule Bitcoinex.Segwit do
 
   @type error :: atom()
 
+  @doc """
+    Decodes an address and returns its network, witness version, and witness program.
+  """
   @spec decode_address(String.t()) ::
           {:ok, {network, witness_version, witness_program}} | {:error, error}
   def decode_address(address) when is_binary(address) do
@@ -35,6 +37,9 @@ defmodule Bitcoinex.Segwit do
     end
   end
 
+  @doc """
+    Encodes an address string.
+  """
   @spec encode_address(network, witness_version, witness_program) ::
           {:ok, String.t()} | {:error, error}
   def encode_address(network, _, _) when not (network in @supported_network) do

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,4 +1,8 @@
 defmodule Bitcoinex.Utils do
+  @moduledoc """
+  Contains useful utility functions used in Bitcoinex.
+  """
+
   @spec sha256(iodata()) :: binary
   def sha256(str) do
     :crypto.hash(:sha256, str)

--- a/test/base58_test.exs
+++ b/test/base58_test.exs
@@ -1,9 +1,9 @@
 defmodule Bitcoinex.Base58Test do
   use ExUnit.Case
   use ExUnitProperties
-  doctest BitcoinEx.Base58
+  doctest Bitcoinex.Base58
 
-  alias BitcoinEx.Base58
+  alias Bitcoinex.Base58
 
   # From
   @base58_encode_decode [
@@ -185,13 +185,13 @@ defmodule Bitcoinex.Base58Test do
   describe "encode/1" do
     test "properly encodes Base58" do
       for pair <- @valid_base58_strings do
-        [Base58_str, base16_str] = pair
+        [base58_str, base16_str] = pair
 
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        assert Base58_str == Base58.encode(base16_bin)
+        assert base58_str == Base58.encode(base16_bin)
 
         # double check
-        {:ok, _decoded} = Base58.decode(Base58_str)
+        {:ok, _decoded} = Base58.decode(base58_str)
       end
     end
   end
@@ -199,17 +199,17 @@ defmodule Bitcoinex.Base58Test do
   describe "decode/1" do
     test "properly decodes Base58" do
       for pair <- @valid_base58_strings do
-        [Base58_str, base16_str] = pair
+        [base58_str, base16_str] = pair
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        {:ok, decoded} = Base58.decode(Base58_str)
+        {:ok, decoded} = Base58.decode(base58_str)
         assert base16_bin == decoded
       end
     end
 
     test "catches invalid checksums" do
       for pair <- @invalid_base58_strings do
-        [Base58_str, _base16_str] = pair
-        assert {:error, :invalid_checksum} = Base58.decode(Base58_str)
+        [base58_str, _base16_str] = pair
+        assert {:error, :invalid_checksum} = Base58.decode(base58_str)
       end
     end
   end

--- a/test/base58_test.exs
+++ b/test/base58_test.exs
@@ -1,9 +1,9 @@
 defmodule Bitcoinex.Base58Test do
   use ExUnit.Case
   use ExUnitProperties
-  doctest Bitcoinex.Base58Check
+  doctest BitcoinEx.Base58
 
-  alias Bitcoinex.Base58Check
+  alias BitcoinEx.Base58
 
   # From
   @base58_encode_decode [
@@ -30,7 +30,7 @@ defmodule Bitcoinex.Base58Test do
   ]
 
   # From https://github.com/bitcoinjs/bs58check/blob/master/test/fixtures.json
-  @valid_base58check_strings [
+  @valid_base58_strings [
     ["1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i", "0065a16059864a2fdbc7c99a4723a8395bc6f188eb"],
     ["3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou", "0574f209f6ea907e2ea48f74fae05782ae8a665257"],
     ["mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", "6f53c0307d6851aa0ce7825ba883c6bd9ad242b486"],
@@ -155,7 +155,7 @@ defmodule Bitcoinex.Base58Test do
     ["3ALJH9Y951VCGcVZYAdpA3KchoP9McEj1G", "055ece0cadddc415b1980f001785947120acdb36fc"]
   ]
 
-  @invalid_base58check_strings [
+  @invalid_base58_strings [
     ["Z9inZq4e2HGQRZQezDjFMmqgUE8NwMRok", "Invalid checksum"],
     ["3HK7MezAm6qEZQUMPRf8jX7wDv6zig6Ky8", "Invalid checksum"],
     ["3AW8j12DUk8mgA7kkfZ1BrrzCVFuH1LsXS", "Invalid checksum"]
@@ -167,7 +167,7 @@ defmodule Bitcoinex.Base58Test do
       for pair <- @base58_encode_decode do
         [base16_str, base58_str] = pair
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        assert base16_bin == Base58Check.decode_base!(base58_str)
+        assert base16_bin == Base58.decode_base!(base58_str)
       end
     end
   end
@@ -177,39 +177,39 @@ defmodule Bitcoinex.Base58Test do
       for pair <- @base58_encode_decode do
         [base16_str, base58_str] = pair
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        assert base58_str == Base58Check.encode_base(base16_bin)
+        assert base58_str == Base58.encode_base(base16_bin)
       end
     end
   end
 
   describe "encode/1" do
-    test "properly encodes base58check" do
-      for pair <- @valid_base58check_strings do
-        [base58check_str, base16_str] = pair
+    test "properly encodes Base58" do
+      for pair <- @valid_base58_strings do
+        [Base58_str, base16_str] = pair
 
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        assert base58check_str == Base58Check.encode(base16_bin)
+        assert Base58_str == Base58.encode(base16_bin)
 
         # double check
-        {:ok, _decoded} = Base58Check.decode(base58check_str)
+        {:ok, _decoded} = Base58.decode(Base58_str)
       end
     end
   end
 
   describe "decode/1" do
-    test "properly decodes base58check" do
-      for pair <- @valid_base58check_strings do
-        [base58check_str, base16_str] = pair
+    test "properly decodes Base58" do
+      for pair <- @valid_base58_strings do
+        [Base58_str, base16_str] = pair
         base16_bin = Base.decode16!(base16_str, case: :lower)
-        {:ok, decoded} = Base58Check.decode(base58check_str)
+        {:ok, decoded} = Base58.decode(Base58_str)
         assert base16_bin == decoded
       end
     end
 
     test "catches invalid checksums" do
-      for pair <- @invalid_base58check_strings do
-        [base58check_str, _base16_str] = pair
-        assert {:error, :invalid_checksum} = Base58Check.decode(base58check_str)
+      for pair <- @invalid_base58_strings do
+        [Base58_str, _base16_str] = pair
+        assert {:error, :invalid_checksum} = Base58.decode(Base58_str)
       end
     end
   end

--- a/test/bitcoinex_test.exs
+++ b/test/bitcoinex_test.exs
@@ -1,8 +1,0 @@
-defmodule BitcoinexTest do
-  use ExUnit.Case
-  doctest Bitcoinex
-
-  test "greets the world" do
-    assert Bitcoinex.hello() == :world
-  end
-end


### PR DESCRIPTION
PR adds more comments to modules, functions, and types.

Along the way, I remove some stale comments and changed a few public functions in `Bitcoinex.LightningNetwork` to private. 

Changed `Bitcoinex.Base58Check` to `Bitcoinex.Base58` for clarity and consistency's sake. For our bech32 encoding, we call it Bitcoinex.Bech32 - not Bech32Check. 