### PR TITLE
support bech32m

### DIFF
--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -62,7 +62,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   """
   @spec decode(String.t()) :: {:ok, t} | {:error, error}
   def decode(invoice) when is_binary(invoice) do
-    with {:ok, {hrp, data}} <- Bech32.decode(invoice, :infinity),
+    with {:ok, {_encoding_type, hrp, data}} <- Bech32.decode(invoice, :infinity),
          {:ok, {network, amount_msat}} <- parse_hrp(hrp),
          {invoice_data, signature_data} = split_at(data, -@signature_base32_length),
          {:ok, parsed_data} <-

--- a/lib/segwit.ex
+++ b/lib/segwit.ex
@@ -67,7 +67,7 @@ defmodule Bitcoinex.Segwit do
             "bcrt"
         end
 
-      Bech32.encode(hrp, [version | converted_program])
+      Bech32.encode(hrp, [version | converted_program], witness_version_to_bech_encoding(version))
     else
       {:is_program_length_valid, false} ->
         {:error, :invalid_program_length}
@@ -146,4 +146,7 @@ defmodule Bitcoinex.Segwit do
   defp parse_network('tb'), do: {:ok, :testnet}
   defp parse_network('bcrt'), do: {:ok, :regtest}
   defp parse_network(_), do: {:error, :invalid_network}
+
+  defp witness_version_to_bech_encoding(0), do: :bech32
+  defp witness_version_to_bech_encoding(witver) when witver in 1..16, do: :bech32m
 end

--- a/test/bech32_test.exs
+++ b/test/bech32_test.exs
@@ -101,7 +101,7 @@ defmodule Bitcoinex.Bech32Test do
   describe "decode/1 for bech32" do
     test "successfully decode with valid bech32" do
       for bech <- @valid_bech32 do
-        assert {:ok, {hrp, data}} = Bech32.decode(bech)
+        assert {:ok, {:bech32, hrp, data}} = Bech32.decode(bech)
         assert hrp != nil
 
         # encode after decode should be the same(after downcase) as before
@@ -170,7 +170,7 @@ defmodule Bitcoinex.Bech32Test do
   describe "decode/1 for bech32m" do
     test "successfully decode with valid bech32" do
       for bech <- @valid_bech32m do
-        assert {:ok, {hrp, data}} = Bech32.decode(bech)
+        assert {:ok, {:bech32m, hrp, data}} = Bech32.decode(bech)
         assert hrp != nil
 
         # encode after decode should be the same(after downcase) as before

--- a/test/bech32_test.exs
+++ b/test/bech32_test.exs
@@ -4,6 +4,7 @@ defmodule Bitcoinex.Bech32Test do
 
   alias Bitcoinex.Bech32
 
+  # Bech32
   @valid_bech32 [
     "A12UEL5L",
     "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
@@ -48,14 +49,63 @@ defmodule Bitcoinex.Bech32Test do
     <<"de1lg7wt", 0xFF::utf8>>
   ]
 
-  describe "decode/1" do
+  # Bech32m
+  @valid_bech32m [
+    "A1LQFN3A",
+    "a1lqfn3a",
+    "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+    "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+    "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+    "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+    "?1v759aa"
+  ]
+
+  @invalid_bech32m_hrp_char_out_of_range [
+    <<0x20, "1xj0phk">>,
+    <<0x7F, "1g6xzxy">>,
+    <<0x90::utf8, "1vctc34">>
+  ]
+
+  @invalid_bech32m_max_length_exceeded [
+    "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4"
+  ]
+
+  @invalid_bech32m_no_separator_character [
+    "qyrz8wqd2c9m"
+  ]
+
+  @invalid_bech32m_empty_hrp [
+    "1qyrz8wqd2c9m",
+    "16plkw9",
+    "1p2gdwpf"
+  ]
+
+  @invalid_bech32m_checksum [
+    "M1VUXWEZ"
+  ]
+
+  @invalid_bech32m_invalid_data_character [
+    "y1b0jsk6g",
+    "lt1igcx5c0"
+  ]
+
+  @invalid_bech32m_too_short_checksum [
+    "in1muywd"
+  ]
+
+  @invalid_bech32m_invalid_character_in_checksum [
+    "mm1crxm3i",
+    "au1s5cgom"
+  ]
+
+  describe "decode/1 for bech32" do
     test "successfully decode with valid bech32" do
       for bech <- @valid_bech32 do
         assert {:ok, {hrp, data}} = Bech32.decode(bech)
         assert hrp != nil
 
         # encode after decode should be the same(after downcase) as before
-        {:ok, new_bech} = Bech32.encode(hrp, data)
+        {:ok, new_bech} = Bech32.encode(hrp, data, :bech32)
         assert new_bech == String.downcase(bech)
       end
     end
@@ -117,33 +167,132 @@ defmodule Bitcoinex.Bech32Test do
     end
   end
 
-  describe "encode/2" do
+  describe "decode/1 for bech32m" do
+    test "successfully decode with valid bech32" do
+      for bech <- @valid_bech32m do
+        assert {:ok, {hrp, data}} = Bech32.decode(bech)
+        assert hrp != nil
+
+        # encode after decode should be the same(after downcase) as before
+        {:ok, new_bech} = Bech32.encode(hrp, data, :bech32m)
+        assert new_bech == String.downcase(bech)
+      end
+    end
+
+    test "fail to decode with invalid bech32m out of ranges" do
+      for bech <- @invalid_bech32m_hrp_char_out_of_range do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :hrp_char_out_opf_range
+      end
+    end
+
+    test "fail to decode with invalid bech32m overall max length exceeded" do
+      for bech <- @invalid_bech32m_max_length_exceeded do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :overall_max_length_exceeded
+      end
+    end
+
+    test "fail to decode with invalid bech32m no separator character" do
+      for bech <- @invalid_bech32m_no_separator_character do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :no_separator_character
+      end
+    end
+
+    test "fail to decode with invalid bech32m empty hrp" do
+      for bech <- @invalid_bech32m_empty_hrp do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :empty_hrp
+      end
+    end
+
+    test "fail to decode with invalid data character" do
+      for bech <- @invalid_bech32m_invalid_data_character do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :contain_invalid_data_char
+      end
+    end
+
+    test "fail to decode with too short checksum" do
+      for bech <- @invalid_bech32m_too_short_checksum do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :too_short_checksum
+      end
+    end
+
+    test "fail to decode with invalid character in checksum" do
+      for bech <- @invalid_bech32m_invalid_character_in_checksum do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :contain_invalid_data_char
+      end
+    end
+
+    test "fail to decode with invalid checksum" do
+      for bech <- @invalid_bech32m_checksum do
+        assert {:error, msg} = Bech32.decode(bech)
+        assert msg == :invalid_checksum
+      end
+    end
+  end
+
+  describe "encode/2 for bech32" do
     test "successfully encode with valid hrp and empty data" do
-      assert {:ok, _bech} = Bech32.encode("bc", [])
+      assert {:ok, _bech} = Bech32.encode("bc", [], :bech32)
     end
 
     test "successfully encode with valid hrp and non empty valid data" do
-      assert {:ok, _bech} = Bech32.encode("bc", [1, 2])
+      assert {:ok, _bech} = Bech32.encode("bc", [1, 2], :bech32)
     end
 
     test "successfully encode with invalid string data" do
-      assert {:ok, _bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+      assert {:ok, _bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7l", :bech32)
     end
 
     test "fail to encode with valid hrp and non empty valid string data" do
-      assert {:error, bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7lo")
+      assert {:error, bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7lo", :bech32)
     end
 
     test "fail to encode with overall encoded length is over 90" do
       data = for _ <- 1..82, do: 1
-      assert {:error, :overall_max_length_exceeded} = Bech32.encode("bc", data)
+      assert {:error, :overall_max_length_exceeded} = Bech32.encode("bc", data, :bech32)
     end
 
     test "fail to encode with hrp contain invalid char(out of 1 to 83 US-ASCII)" do
       data = [1]
-      assert {:error, :hrp_char_out_opf_range} = Bech32.encode(" ", data)
-      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("\ł", data)
-      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("中文", data)
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode(" ", data, :bech32)
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("\ł", data, :bech32)
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("中文", data, :bech32)
+    end
+  end
+
+  describe "encode/2 for bech32m" do
+    test "successfully encode with valid hrp and empty data" do
+      assert {:ok, _bech} = Bech32.encode("bc", [], :bech32m)
+    end
+
+    test "successfully encode with valid hrp and non empty valid data" do
+      assert {:ok, _bech} = Bech32.encode("bc", [1, 2], :bech32m)
+    end
+
+    test "successfully encode with invalid string data" do
+      assert {:ok, _bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7l", :bech32m)
+    end
+
+    test "fail to encode with valid hrp and non empty valid string data" do
+      assert {:error, bech} = Bech32.encode("bc", "qpzry9x8gf2tvdw0s3jn54khce6mua7lo", :bech32m)
+    end
+
+    test "fail to encode with overall encoded length is over 90" do
+      data = for _ <- 1..82, do: 1
+      assert {:error, :overall_max_length_exceeded} = Bech32.encode("bc", data, :bech32m)
+    end
+
+    test "fail to encode with hrp contain invalid char(out of 1 to 83 US-ASCII)" do
+      data = [1]
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode(" ", data, :bech32m)
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("\ł", data, :bech32m)
+      assert {:error, :hrp_char_out_opf_range} = Bech32.encode("中文", data, :bech32m)
     end
   end
 end

--- a/test/segwit_test.exs
+++ b/test/segwit_test.exs
@@ -11,12 +11,16 @@ defmodule Bitcoinex.SegwitTest do
     {"bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
      "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"},
     {"BC1SW50QGDZ25J", "6002751e"},
-    {"bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"}
+    {"bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"},
+    {"bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+     "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"}
   ]
 
   @valid_segwit_address_hexscript_pairs_testnet [
     {"tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
      "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"},
+    {"tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+     "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"},
     {"tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
      "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"}
   ]
@@ -29,9 +33,22 @@ defmodule Bitcoinex.SegwitTest do
   ]
 
   @invalid_segwit_addresses [
+    "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+    "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+    "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+    "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+    "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+    "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+    "bc1pw5dgrnzv",
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
     "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
     "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
     "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+    "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+    "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
     "bc1rw5uspcuh",
     "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
     "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",

--- a/test/segwit_test.exs
+++ b/test/segwit_test.exs
@@ -8,10 +8,10 @@ defmodule Bitcoinex.SegwitTest do
   @valid_segwit_address_hexscript_pairs_mainnet [
     {"BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4",
      "0014751e76e8199196d454941c45d1b3a323f1433bd6"},
-    {"bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+    {"bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
      "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"},
-    {"BC1SW50QA3JX3S", "6002751e"},
-    {"bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323"}
+    {"BC1SW50QGDZ25J", "6002751e"},
+    {"bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"}
   ]
 
   @valid_segwit_address_hexscript_pairs_testnet [


### PR DESCRIPTION
bip350 is merged. This PR add support for bech32m. I added all new test vector from [bip350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#Test_vectors)