### PR TITLE
Validate Taproot Addresses

### DIFF
--- a/lib/address.ex
+++ b/lib/address.ex
@@ -15,7 +15,7 @@ defmodule Bitcoinex.Address do
     * p2wsh: Pay-To-Witness-Script-Hash
   """
   @type address_type :: :p2pkh | :p2sh | :p2wpkh | :p2wsh
-  @address_types ~w(p2pkh p2sh p2wpkh p2wsh)a
+  @address_types ~w(p2pkh p2sh p2wpkh p2wsh p2tr)a
 
   @doc """
   Accepts a public key hash, network, and address_type and returns its address.
@@ -77,6 +77,21 @@ defmodule Bitcoinex.Address do
     case Segwit.decode_address(address) do
       {:ok, {^network_name, witness_version, witness_program}}
       when witness_version == 0 and length(witness_program) == 32 ->
+        true
+
+      # network is not same as network set in config
+      {:ok, {_network_name, _, _}} ->
+        false
+
+      {:error, _error} ->
+        false
+    end
+  end
+
+  def is_valid?(address, network_name, :p2tr) do
+    case Segwit.decode_address(address) do
+      {:ok, {^network_name, witness_version, witness_program}}
+      when witness_version == 1 and length(witness_program) == 32 ->
         true
 
       # network is not same as network set in config

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -103,7 +103,14 @@ defmodule Bitcoinex.AddressTest do
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
         "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
-        "bc1gmk9yu"
+        "bc1gmk9yu",
+        # p2tr addresses
+        "bc1pqyqszqgpqyqszqgpqyqszqppgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9e",
+        "bc1p0xlxvlhemja6c4dqv22uapctqupfpphlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+        "bc1pqyqszqgpqyqszqgpqyqszgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9e",
+        "bc1p0xlxvlhemja6c4dqv22uapctquphlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+        "bc1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9f",
+        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj1"
       ]
 
       {:ok,
@@ -148,21 +155,25 @@ defmodule Bitcoinex.AddressTest do
            valid_testnet_segwit_addresses: valid_testnet_segwit_addresses,
            valid_testnet_p2pkh_addresses: valid_testnet_p2pkh_addresses,
            valid_testnet_p2sh_addresses: valid_testnet_p2sh_addresses,
-           valid_regtest_segwit_addresses: valid_regtest_segwit_addresses
+           valid_regtest_segwit_addresses: valid_regtest_segwit_addresses,
+           valid_testnet_p2tr_addresses: valid_testnet_p2tr_addresses
          } do
       all_valid_testnet_addresses =
         valid_testnet_segwit_addresses ++
           valid_testnet_p2pkh_addresses ++
-          valid_testnet_p2sh_addresses ++ valid_regtest_segwit_addresses
+          valid_testnet_p2sh_addresses ++
+          valid_regtest_segwit_addresses ++
+          valid_testnet_p2tr_addresses
 
       for valid_testnet_address <- all_valid_testnet_addresses do
         refute Address.is_valid?(valid_testnet_address, :mainnet)
       end
     end
 
-    test "return false when the address is not valid address either p2sh, p2pkh, pwsh, p2wpkh", %{
-      invalid_addresses: invalid_addresses
-    } do
+    test "return false when the address is not valid address either p2sh, p2pkh, pwsh, p2wpkh, p2tr",
+         %{
+           invalid_addresses: invalid_addresses
+         } do
       all_invalid_addresses = invalid_addresses
 
       for invalid_address <- all_invalid_addresses do
@@ -182,7 +193,9 @@ defmodule Bitcoinex.AddressTest do
       valid_mainnet_p2wpkh_addresses: valid_mainnet_p2wpkh_addresses,
       valid_testnet_p2wpkh_addresses: valid_testnet_p2wpkh_addresses,
       valid_mainnet_p2wsh_addresses: valid_mainnet_p2wsh_addresses,
-      valid_testnet_p2wsh_addresses: valid_testnet_p2wsh_addresses
+      valid_testnet_p2wsh_addresses: valid_testnet_p2wsh_addresses,
+      valid_mainnet_p2tr_addresses: valid_mainnet_p2tr_addresses,
+      valid_testnet_p2tr_addresses: valid_testnet_p2tr_addresses
     } do
       for mainnet_p2pkh <- valid_mainnet_p2pkh_addresses do
         assert Address.decode_type(mainnet_p2pkh, :mainnet) == {:ok, :p2pkh}
@@ -214,6 +227,14 @@ defmodule Bitcoinex.AddressTest do
 
       for testnet_p2wsh <- valid_testnet_p2wsh_addresses do
         assert Address.decode_type(testnet_p2wsh, :testnet) == {:ok, :p2wsh}
+      end
+
+      for mainnet_p2tr <- valid_mainnet_p2tr_addresses do
+        assert Address.decode_type(mainnet_p2tr, :mainnet) == {:ok, :p2tr}
+      end
+
+      for testnet_p2tr <- valid_testnet_p2tr_addresses do
+        assert Address.decode_type(testnet_p2tr, :testnet) == {:ok, :p2tr}
       end
     end
   end

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -56,26 +56,37 @@ defmodule Bitcoinex.AddressTest do
         "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7"
       ]
 
+      valid_mainnet_p2tr_addresses = [
+        "bc1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9e",
+        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0"
+      ]
+
+      valid_testnet_p2tr_addresses = [
+        "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c"
+      ]
+
       valid_mainnet_addresses =
         valid_mainnet_p2pkh_addresses ++
           valid_mainnet_p2sh_addresses ++
           valid_mainnet_segwit_addresses ++
           valid_mainnet_p2wpkh_addresses ++
-          valid_mainnet_p2wsh_addresses
+          valid_mainnet_p2wsh_addresses ++
+          valid_mainnet_p2tr_addresses
 
       valid_testnet_addresses =
         valid_testnet_p2pkh_addresses ++
           valid_testnet_p2sh_addresses ++
           valid_testnet_segwit_addresses ++
           valid_testnet_p2wpkh_addresses ++
-          valid_testnet_p2wsh_addresses
+          valid_testnet_p2wsh_addresses ++
+          valid_testnet_p2tr_addresses
 
       valid_regtest_addresses =
         valid_testnet_p2pkh_addresses ++
           valid_testnet_p2sh_addresses ++ valid_regtest_segwit_addresses
 
       invalid_addresses = [
-        # witness v1 address
+        # witness v1 address using bech32 (not bech32m) encoding
         "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
         "BC1SW50QA3JX3S",
         "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
@@ -110,17 +121,22 @@ defmodule Bitcoinex.AddressTest do
        valid_testnet_p2wpkh_addresses: valid_testnet_p2wpkh_addresses,
        valid_mainnet_p2wsh_addresses: valid_mainnet_p2wsh_addresses,
        valid_testnet_p2wsh_addresses: valid_testnet_p2wsh_addresses,
+       valid_mainnet_p2tr_addresses: valid_mainnet_p2tr_addresses,
+       valid_testnet_p2tr_addresses: valid_testnet_p2tr_addresses,
        invalid_addresses: invalid_addresses}
     end
 
-    test "return true when the address is valid address either p2sh, p2pkh, pwsh, p2wpkh", %{
-      valid_mainnet_p2pkh_addresses: valid_mainnet_p2pkh_addresses,
-      valid_mainnet_p2sh_addresses: valid_mainnet_p2sh_addresses,
-      valid_mainnet_segwit_addresses: valid_mainnet_segwit_addresses
-    } do
+    test "return true when the address is valid address either p2sh, p2pkh, pwsh, p2wpkh, p2tr",
+         %{
+           valid_mainnet_p2pkh_addresses: valid_mainnet_p2pkh_addresses,
+           valid_mainnet_p2sh_addresses: valid_mainnet_p2sh_addresses,
+           valid_mainnet_segwit_addresses: valid_mainnet_segwit_addresses,
+           valid_mainnet_p2tr_addresses: valid_mainnet_p2tr_addresses
+         } do
       all_valid_addresses =
         valid_mainnet_p2sh_addresses ++
-          valid_mainnet_p2pkh_addresses ++ valid_mainnet_segwit_addresses
+          valid_mainnet_p2pkh_addresses ++
+          valid_mainnet_segwit_addresses ++ valid_mainnet_p2tr_addresses
 
       for valid_address <- all_valid_addresses do
         assert Address.is_valid?(valid_address, :mainnet)

--- a/test/script_test.exs
+++ b/test/script_test.exs
@@ -94,6 +94,42 @@ defmodule Bitcoinex.ScriptTest do
     "0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d"
   ]
 
+  # from 
+  # https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#test-vectors-for-v0-v16-native-segregated-witness-addresses
+  # test vectors that are not valid v0 or v1 scripts have been removed.
+  @bip350_test_vectors [
+    %{
+      b32: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      hex: "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+      net: :mainnet
+    },
+    %{
+      b32: "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+      hex: "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+      net: :testnet
+    },
+    %{
+      b32: "bc1pqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsyjer9e",
+      hex: "51200101010101010101010101010101010101010101010101010101010101010101",
+      net: :mainnet
+    },
+    %{
+      b32: "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
+      hex: "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+      net: :testnet
+    },
+    %{
+      b32: "tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+      hex: "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+      net: :testnet
+    },
+    %{
+      b32: "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+      hex: "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      net: :mainnet
+    }
+  ]
+
   describe "test basics functions" do
     test "test new/0 and empty?/1" do
       s = Script.new()
@@ -1089,6 +1125,13 @@ defmodule Bitcoinex.ScriptTest do
         end
       end
     end
+
+    test "test bip350 test vectors" do
+      for t <- @bip350_test_vectors do
+        {:ok, s} = Script.parse_script(t.hex)
+        assert Script.to_address(s, t.net) == {:ok, t.b32}
+      end
+    end
   end
 
   describe "test from_address" do
@@ -1190,6 +1233,14 @@ defmodule Bitcoinex.ScriptTest do
       {:ok, script, network} = Script.from_address(addr)
       assert Script.is_p2wpkh?(script)
       assert network == :mainnet
+    end
+
+    test "test bip350 test vectors" do
+      for t <- @bip350_test_vectors do
+        {:ok, s, net} = Script.from_address(t.b32)
+        assert Script.to_hex(s) == t.hex
+        assert net == t.net
+      end
     end
   end
 


### PR DESCRIPTION
- add p2tr as option for `Address.is_valid?`
- Fix `Script.to_address` and `Script.from_address` for Taproot. 

TODO: I could not find many p2tr addresses/scripts test vectors. 