### PR TITLE
add sign message function

### DIFF
--- a/lib/secp256k1/privatekey.ex
+++ b/lib/secp256k1/privatekey.ex
@@ -195,8 +195,8 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
 
   @doc """
   sign returns an ECDSA signature using the privkey and z
-  where privkey is a PrivateKey object and z is an integer. 
-  The nonce is derived using RFC6979. 
+  where privkey is a PrivateKey object and z is an integer.
+  The nonce is derived using RFC6979.
   """
   @spec sign(t(), integer) :: Signature.t()
   def sign(privkey, z) do
@@ -220,15 +220,15 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
   end
 
   @doc """
-  sign_message returns an ECDSA signature using the privkey and msg
-  where privkey is a PrivateKey object and msg is a binary message to be hashed. 
-  The message is hashed using hash256 (double SHA256) and the nonce is derived 
-  using RFC6979. 
+  sign_message returns an ECDSA signature using the privkey and "Bitcoin Signed Message: <msg>"
+  where privkey is a PrivateKey object and msg is a binary message to be hashed.
+  The message is hashed using hash256 (double SHA256) and the nonce is derived
+  using RFC6979.
   """
-  @spec sign(t(), binary) :: Signature.t()
+  @spec sign_message(t(), binary) :: Signature.t()
   def sign_message(privkey, msg) do
     z =
-      msg
+      ("Bitcoin Signed Message: " <> msg)
       |> Bitcoinex.Utils.double_sha256()
       |> :binary.decode_unsigned()
 

--- a/lib/secp256k1/privatekey.ex
+++ b/lib/secp256k1/privatekey.ex
@@ -228,7 +228,7 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
   @spec sign_message(t(), binary) :: Signature.t()
   def sign_message(privkey, msg) do
     z =
-      ("Bitcoin Signed Message: " <> msg)
+      ("Bitcoin Signed Message:\n" <> msg)
       |> Bitcoinex.Utils.double_sha256()
       |> :binary.decode_unsigned()
 

--- a/lib/secp256k1/privatekey.ex
+++ b/lib/secp256k1/privatekey.ex
@@ -218,4 +218,20 @@ defmodule Bitcoinex.Secp256k1.PrivateKey do
         end
     end
   end
+
+  @doc """
+  sign_message returns an ECDSA signature using the privkey and msg
+  where privkey is a PrivateKey object and msg is a binary message to be hashed. 
+  The message is hashed using hash256 (double SHA256) and the nonce is derived 
+  using RFC6979. 
+  """
+  @spec sign(t(), binary) :: Signature.t()
+  def sign_message(privkey, msg) do
+    z =
+      msg
+      |> Bitcoinex.Utils.double_sha256()
+      |> :binary.decode_unsigned()
+
+    sign(privkey, z)
+  end
 end


### PR DESCRIPTION
Currently, `sign` function signs a sighash. Sign message is a helpful function to sign actual data. 