### PR TITLE
Add PSBT to/from file & script hash helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ bitcoinex-*.tar
 # dialyzer plt
 /_plts/*.plt
 /_plts/*.plt.hash
+
+# idea
+.idea/
+
+# bitcoin related files
+**/*.psbt

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -62,12 +62,10 @@ defmodule Bitcoinex.PSBT do
   @doc """
     to_file writes a PSBT to file as binary.
   """
-  @spec to_file(%Bitcoinex.PSBT{}, String.t()) :: atom
+  @spec to_file(%Bitcoinex.PSBT{}, String.t()) :: :ok | {:error, File.posix}
   def to_file(packet, filename) do
     bin = serialize(packet)
-    {:ok, file} = File.open(filename, [:write])
-    :ok = IO.binwrite(file, bin)
-    File.close(file)
+    File.write(filename, bin)
   end
 
   @spec encode_b64(%Bitcoinex.PSBT{}) :: String.t()

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -62,7 +62,7 @@ defmodule Bitcoinex.PSBT do
   @doc """
     to_file writes a PSBT to file as binary.
   """
-  @spec to_file(%Bitcoinex.PSBT{}, String.t()) :: :ok | {:error, File.posix}
+  @spec to_file(%Bitcoinex.PSBT{}, String.t()) :: :ok | {:error, File.posix()}
   def to_file(packet, filename) do
     bin = serialize(packet)
     File.write(filename, bin)

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -31,14 +31,21 @@ defmodule Bitcoinex.PSBT do
   def decode(psbt_b64) when is_binary(psbt_b64) do
     case Base.decode64(psbt_b64, case: :lower) do
       {:ok, psbt_b64} ->
-        case parse(psbt_b64) do
-          {:ok, txn} ->
-            {:ok, txn}
-        end
+        parse(psbt_b64)
 
       :error ->
         {:error, :decode_error}
     end
+  end
+
+  @doc """
+    Decodes a binary-encoded PSBT file.
+  """
+  @spec from_file(String.t()) :: {:ok, %Bitcoinex.PSBT{}} | {:error, term()}
+  def from_file(filename) do
+    filename
+    |> File.read!()
+    |> parse()
   end
 
   @spec serialize(%Bitcoinex.PSBT{}) :: binary
@@ -52,9 +59,22 @@ defmodule Bitcoinex.PSBT do
       global <> inputs <> outputs
   end
 
+  @doc """
+    to_file writes a PSBT to file as binary.
+  """
+  @spec to_file(%Bitcoinex.PSBT{}, String.t()) :: atom
+  def to_file(packet, filename) do
+    bin = serialize(packet)
+    {:ok, file} = File.open(filename, [:write])
+    :ok = IO.binwrite(file, bin)
+    File.close(file)
+  end
+
   @spec encode_b64(%Bitcoinex.PSBT{}) :: String.t()
   def encode_b64(packet) do
-    serialize(packet) |> Base.encode64()
+    packet
+    |> serialize()
+    |> Base.encode64()
   end
 
   defp parse(<<@magic::big-size(32), @separator::big-size(8), psbt::binary>>) do
@@ -88,21 +108,18 @@ defmodule Bitcoinex.PSBT.Utils do
 
   # parses key value pairs with a provided parse function
   def parse_key_value(psbt, kv, parse_func) do
-    {kv, psbt} =
-      case psbt do
-        # separator
-        <<0x00::big-size(8), psbt::binary>> ->
-          {kv, psbt}
+    case psbt do
+      # separator
+      <<0x00::big-size(8), psbt::binary>> ->
+        {kv, psbt}
 
-        _ ->
-          case parse_compact_size_value(psbt) do
-            {key, psbt} ->
-              {kv, psbt} = parse_func.(key, psbt, kv)
-              parse_key_value(psbt, kv, parse_func)
-          end
-      end
-
-    {kv, psbt}
+      _ ->
+        case parse_compact_size_value(psbt) do
+          {key, psbt} ->
+            {kv, psbt} = parse_func.(key, psbt, kv)
+            parse_key_value(psbt, kv, parse_func)
+        end
+    end
   end
 
   def serialize_kv(key, val) do

--- a/lib/script.ex
+++ b/lib/script.ex
@@ -68,7 +68,7 @@ defmodule Bitcoinex.Script do
   end
 
   @doc """
-    hash160 is a helper function which returns the hash160 
+    hash160 is a helper function which returns the hash160
     digest of the serialized script, as used in P2SH scripts.
   """
   @spec hash160(t()) :: binary
@@ -102,7 +102,7 @@ defmodule Bitcoinex.Script do
   def get_op_atom(i), do: if(i > 0 and i < 0x4C, do: i, else: Map.fetch(opcode_nums(), i))
 
   @doc """
-  	pop returns the first element of the script and the remaining script. 
+  	pop returns the first element of the script and the remaining script.
   	Returns nil if script is empty
   """
   @spec pop(t()) :: nil | {:ok, non_neg_integer() | binary, t()}
@@ -132,7 +132,7 @@ defmodule Bitcoinex.Script do
   end
 
   @doc """
-  	push_data returns a script with the binary data and any 
+  	push_data returns a script with the binary data and any
   	accompanying pushdata or pushbytes opcodes added to the front of the script.
   """
   @spec push_data(t(), binary) :: {:ok, t()} | {:error, String.t()}
@@ -158,7 +158,7 @@ defmodule Bitcoinex.Script do
     end
   end
 
-  # SERIALIZE & PARSE 
+  # SERIALIZE & PARSE
   defp serializer(%__MODULE__{items: []}, acc), do: acc
 
   defp serializer(%__MODULE__{items: [item | script]}, acc) when is_integer(item) do
@@ -190,25 +190,22 @@ defmodule Bitcoinex.Script do
       len <= 0xFFFFFFFF ->
         len = Utils.int_to_little(len, 4)
         serializer(%__MODULE__{items: script}, acc <> len <> item)
-
-      true ->
-        {:error, "data is too long"}
     end
   end
 
   @doc """
-  	serialize_script serializes the script into binary 
+  	serialize_script serializes the script into binary
   	according to Bitcoin's standard.
   """
   @spec serialize_script(t()) :: binary
   def serialize_script(script = %__MODULE__{}) do
-    # serialize_script(%Script{items: [0x51]}) will still display "Q" but 
+    # serialize_script(%Script{items: [0x51]}) will still display "Q" but
     # it functions as binary 0x51. Use to_hex for displaying scripts.
     serializer(script, <<>>)
   end
 
   @doc """
-  	to_hex returns the hex of a serialized script. 
+  	to_hex returns the hex of a serialized script.
   """
   @spec to_hex(t()) :: String.t()
   def to_hex(script) do
@@ -412,7 +409,7 @@ defmodule Bitcoinex.Script do
   defp test_multi(_, _, _), do: false
 
   @doc """
-    extract_multi_policy takes in a raw multisig script and returns the m, the 
+    extract_multi_policy takes in a raw multisig script and returns the m, the
     number of signatures required and the n authorized public keys.
   """
   @spec extract_multi_policy(t()) ::
@@ -493,6 +490,17 @@ defmodule Bitcoinex.Script do
   def create_p2sh(_), do: {:error, "script hash must be a #{@h160_length}-byte hash"}
 
   @doc """
+    to_p2sh wraps any script in a p2sh by first hashing it (hash160)
+    and then wrapping then script hash in a p2sh script.
+  """
+  @spec to_p2sh(t()) :: {:ok, t()} | {:error, String.t()}
+  def to_p2sh(script = %__MODULE__{}) do
+    script
+    |> hash160()
+    |> create_p2sh()
+  end
+
+  @doc """
     create_multi creates a raw multisig script using m and the list of public keys.
   """
   @spec create_multi(non_neg_integer(), list(Point.t())) :: {:ok, t()} | {:error, String.t()}
@@ -520,7 +528,7 @@ defmodule Bitcoinex.Script do
   defp fill_multi_keys(_, _), do: raise(ArgumentError)
 
   @doc """
-    create_p2sh_multi returns both a P2SH-wrapped multisig script 
+    create_p2sh_multi returns both a P2SH-wrapped multisig script
     and the underlying raw multisig script using m and the list of public keys.
   """
   @spec create_p2sh_multi(non_neg_integer(), list(Point.t())) ::
@@ -538,7 +546,7 @@ defmodule Bitcoinex.Script do
   end
 
   @doc """
-    create_p2wsh_multi returns both a P2WSH-wrapped multisig script 
+    create_p2wsh_multi returns both a P2WSH-wrapped multisig script
     and the underlying raw multisig script using m and the list of public keys.
   """
   @spec create_p2wsh_multi(non_neg_integer(), list(Point.t())) ::
@@ -557,7 +565,7 @@ defmodule Bitcoinex.Script do
 
   @doc """
   	create_witness_scriptpubkey creates any witness script from a witness version
-  	and witness program. It performs no validity checks. 
+  	and witness program. It performs no validity checks.
   """
   @spec create_witness_scriptpubkey(non_neg_integer(), binary) :: {:ok, t()}
   def create_witness_scriptpubkey(version, witness_program) do
@@ -581,6 +589,17 @@ defmodule Bitcoinex.Script do
   @spec create_p2wsh(binary) :: {:ok, t()}
   def create_p2wsh(<<sh::binary-size(@wsh_length)>>), do: create_witness_scriptpubkey(0, sh)
   def create_p2wsh(_), do: {:error, "script hash must be a #{@wsh_length}-byte hash"}
+
+  @doc """
+    to_p2wsh converts any script into a p2wsh script by hashing it (SHA256)
+    then wrapping the script hash as a p2wsh script.
+  """
+  @spec to_p2wsh(t()) :: {:ok, t()}
+  def to_p2wsh(script = %__MODULE__{}) do
+    script
+    |> sha256()
+    |> create_p2wsh()
+  end
 
   @doc """
   	create_p2tr creates a p2tr script using the passed 32-byte public key
@@ -611,7 +630,7 @@ defmodule Bitcoinex.Script do
   # CREATE SCRIPTS FROM PUBKEYS
 
   @doc """
-  	public_key_hash takes the hash160 of the public key's compressed sec encoding. 
+  	public_key_hash takes the hash160 of the public key's compressed sec encoding.
   	Can be used to create a pkh script.
   """
   @spec public_key_hash(Point.t()) :: binary
@@ -622,7 +641,7 @@ defmodule Bitcoinex.Script do
   end
 
   @doc """
-  	public_key_to_p2pkh creates a p2pkh script from a public key. 
+  	public_key_to_p2pkh creates a p2pkh script from a public key.
   	All public keys are compressed.
   """
   @spec public_key_to_p2pkh(Point.t()) :: {:ok, t()}
@@ -635,7 +654,7 @@ defmodule Bitcoinex.Script do
   def public_key_to_p2pkh(_), do: {:error, "invalid public key"}
 
   @doc """
-  	public_key_to_p2wpkh creates a p2wpkh script from a public key. 
+  	public_key_to_p2wpkh creates a p2wpkh script from a public key.
   	All public keys are compressed.
   """
   @spec public_key_to_p2wpkh(Point.t()) :: {:ok, t()}
@@ -648,7 +667,7 @@ defmodule Bitcoinex.Script do
   def public_key_to_p2wpkh(_), do: {:error, "invalid public key"}
 
   @doc """
-  	public_key_to_p2sh_p2wpkh creates a p2sh-p2wpkh script from a public key. 
+  	public_key_to_p2sh_p2wpkh creates a p2sh-p2wpkh script from a public key.
   	All public keys are compressed.
   """
   @spec public_key_to_p2sh_p2wpkh(Point.t()) :: {:ok, t(), t()}
@@ -669,7 +688,7 @@ defmodule Bitcoinex.Script do
           {:error, String.t()} | {:ok, t(), Bitcoinex.Network.network_name()}
   def from_address(addr) do
     case String.slice(addr, 0, 2) do
-      # segwit addresses 
+      # segwit addresses
       p when p in ["bc", "tb"] ->
         case Segwit.decode_address(addr) do
           {:ok, {network, version, program}} ->
@@ -748,7 +767,7 @@ defmodule Bitcoinex.Script do
         {:ok, <<res::binary-size(@h160_length)>>, _script} = pop(script)
         {:ok, Address.encode(res, network, :p2sh)}
 
-      # p2pkh 
+      # p2pkh
       0x76 ->
         {:ok, 0xA9, script} = pop(script)
         {:ok, @h160_length, script} = pop(script)

--- a/test/psbt_test.exs
+++ b/test/psbt_test.exs
@@ -591,4 +591,28 @@ defmodule Bitcoinex.PSBTTest do
       end
     end
   end
+
+  describe "to_file/2 & from_file/1" do
+    test "valid psbts" do
+      filename = "./test/psbt-test.psbt"
+
+      for valid_psbt <- @valid_psbts do
+        case PSBT.decode(valid_psbt.psbt) do
+          {:ok, psbt_in} ->
+            PSBT.to_file(psbt_in, filename)
+            {res, psbt_out} = PSBT.from_file(filename)
+            assert res == :ok
+            assert valid_psbt.expected_global == psbt_out.global
+            assert valid_psbt.expected_in == psbt_out.inputs
+            assert valid_psbt.expected_out == psbt_out.outputs
+            assert valid_psbt.psbt == PSBT.encode_b64(psbt_out)
+
+          {:error, _} ->
+            assert false
+        end
+      end
+
+      File.rm_rf(filename)
+    end
+  end
 end


### PR DESCRIPTION
Add ability to read PSBTs from files and write PSBTs to files. 

Add `to_p2wsh` and `to_p2sh` to wrap an arbitrary script to a script hash script more easily