### PR TITLE
Modify leading-zero check in bolt11 decoding

### DIFF
--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -565,42 +565,46 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   end
 
   defp calculate_milli_satoshi(amount_str) do
-    result =
-      case Regex.run(~r/[munp]$/, amount_str) do
-        [multiplier] when multiplier in @valid_multipliers ->
-          case Integer.parse(String.slice(amount_str, 0..-2)) do
-            {amount, ""} ->
-              {:ok, to_bitcoin(amount, multiplier)}
+    if String.length(amount_str) > 1 and String.starts_with?(amount_str, "0") do
+      {:error, :amount_with_leading_zero}
+    else
+      result =
+        case Regex.run(~r/[munp]$/, amount_str) do
+          [multiplier] when multiplier in @valid_multipliers ->
+            case Integer.parse(String.slice(amount_str, 0..-2)) do
+              {amount, ""} ->
+                {:ok, to_bitcoin(amount, multiplier)}
 
-            _ ->
-              {:error, :invalid_amount}
-          end
+              _ ->
+                {:error, :invalid_amount}
+            end
 
-        _ ->
-          case Integer.parse(amount_str) do
-            {amount_in_bitcoin, ""} ->
-              {:ok, amount_in_bitcoin}
+          _ ->
+            case Integer.parse(amount_str) do
+              {amount_in_bitcoin, ""} ->
+                {:ok, amount_in_bitcoin}
 
-            _ ->
-              {:error, :invalid_amount}
-          end
-      end
-
-    case result do
-      {:ok, amount_in_bitcoin} ->
-        amount_msat_dec = D.mult(amount_in_bitcoin, @milli_satoshi_per_bitcoin)
-        rounded_amount_msat_dec = D.round(amount_msat_dec)
-
-        case D.equal?(rounded_amount_msat_dec, amount_msat_dec) do
-          true ->
-            {:ok, D.to_integer(rounded_amount_msat_dec)}
-
-          false ->
-            {:error, :sub_msat_precision_amount}
+              _ ->
+                {:error, :invalid_amount}
+            end
         end
 
-      {:error, error} ->
-        {:error, error}
+      case result do
+        {:ok, amount_in_bitcoin} ->
+          amount_msat_dec = D.mult(amount_in_bitcoin, @milli_satoshi_per_bitcoin)
+          rounded_amount_msat_dec = D.round(amount_msat_dec)
+
+          case D.equal?(rounded_amount_msat_dec, amount_msat_dec) do
+            true ->
+              {:ok, D.to_integer(rounded_amount_msat_dec)}
+
+            false ->
+              {:error, :sub_msat_precision_amount}
+          end
+
+        {:error, error} ->
+          {:error, error}
+      end
     end
   end
 

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -564,10 +564,6 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     end
   end
 
-  defp calculate_milli_satoshi("0" <> _) do
-    {:error, :amount_with_leading_zero}
-  end
-
   defp calculate_milli_satoshi(amount_str) do
     result =
       case Regex.run(~r/[munp]$/, amount_str) do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -427,6 +427,20 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           description: "",
           min_final_cltv_expiry: 18
         }
+      },
+      # Amount is 1 bitcoin to test no-multiplier parsing
+      {
+        "lnbcrt11p34y28ypp5z4tvam0qzsj6eq7adedy2p0ga2lam4jc3g6kn702t9mj6xyldj6qdqqcqzpgxqyz5vqsp55gkl87n3n8qwqadwrt3gfxcdsls8mk2cv5vgh3v8ujexglxpkv9q9qyyssqjx0f3dgylw8dyhy8z6e4ta3pzg09j90uwhd747fsclx5enjalmprnt583744v683prj48xgc57gumzs2406l5m7jqrem3aewh6nzfkspz9m2px",
+        %Invoice{
+          network: :regtest,
+          destination: "02d60dfe3850d115fdb2114b14396d4d2924a25dafc69098d10841e4474d9977dd",
+          payment_hash: "1556ceede01425ac83dd6e5a4505e8eabfddd6588a3569f9ea59772d189f6cb4",
+          amount_msat: 100_000_000_000,
+          timestamp: 1_666_328_804,
+          expiry: 86_400,
+          description: "",
+          min_final_cltv_expiry: 40
+        }
       }
     ]
 

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -414,6 +414,19 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           description: "simple",
           min_final_cltv_expiry: 40
         }
+      },
+      # Amount is set to 0 explicitly (which might seem like a leading 0, but actually is not)
+      {
+        "lnbcrt01pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdqqnp4q0n326hr8v9zprg8gsvezcch06gfaqqhde2aj730yg0durunfhv66dnh5eqnn4w30z5j59jdxykc077phshmlw5kuzmvd4r5slafnlk7q3grjpy6nvxg9stq4xt58kcr3utla2vz0783x5920vhe0p7md9jspddgapr",
+        %Invoice{
+          network: :regtest,
+          destination: "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
+          payment_hash: "0001020304050607080900010203040506070809000102030405060708090102",
+          amount_msat: 0,
+          timestamp: 1_496_314_658,
+          description: "",
+          min_final_cltv_expiry: 18
+        }
       }
     ]
 


### PR DESCRIPTION
bolt11 invoices with a `0` amount explicitly set, e.g. `lnbcrt01pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdqqnp4q0n326hr8v9zprg8gsvezcch06gfaqqhde2aj730yg0durunfhv66dnh5eqnn4w30z5j59jdxykc077phshmlw5kuzmvd4r5slafnlk7q3grjpy6nvxg9stq4xt58kcr3utla2vz0783x5920vhe0p7md9jspddgapr` are still valid according to `lnd` and other bolt11 decoding tools such as https://lightningdecoder.com/ and https://www.bolt11.org/

However, `Bitcoinex.LightningNetwork.decode` (through the private `parse_hrp` and `calculate_milli_satoshi` functions) will result in an `{:error, :amount_with_leading_zero}` instead of decoding 0-amount invoices as expected.

Instead of pattern matching against a leading "0" this update has `calculate_milli_satoshi` perform the following check:

```
    if String.length(amount_str) > 1 and String.starts_with?(amount_str, "0") do
      {:error, :amount_with_leading_zero}
    else
      <EXISTING LOGIC>
    end
```

This should still prevent `amount`s that are more than just "`0`" from being interpreted as valid.