### PR TITLE
added extra catch all case

### DIFF
--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -59,6 +59,9 @@ defmodule Bitcoinex.Secp256k1.Point do
           {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
           _ -> {:error, "invalid public key"}
         end
+
+      _ ->
+        {:error, "invalid public key"}
     end
   end
 


### PR DESCRIPTION
This throws on invalid keys. If possible could we return some error message like this?

See:
`Bitcoinex.ExtendedKey.parse_extended_key("tpubD6NzVbkrYhZ4WLczPJWReQycCJdd6YVWXubbVUFnJ5KgU5MDQrD998ZJLNGbhd2pq7ZtDiPYTfJ7iBenLVQpYgSQqPjUsQeJXH8VQ8xA67D")
`