### PR TITLE
Eliminate String.slice with -1 warnings

### DIFF
--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -545,7 +545,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
           {:ok, {network_name, nil}}
 
         _ ->
-          amount_str = String.slice(rest_hrp, hrp_segwit_prefix_size..-1)
+          amount_str = String.slice(rest_hrp, hrp_segwit_prefix_size..-1//1)
 
           case calculate_milli_satoshi(amount_str) do
             {:ok, amount} ->
@@ -571,7 +571,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       result =
         case Regex.run(~r/[munp]$/, amount_str) do
           [multiplier] when multiplier in @valid_multipliers ->
-            case Integer.parse(String.slice(amount_str, 0..-2)) do
+            case Integer.parse(String.slice(amount_str, 0..-2//1)) do
               {amount, ""} ->
                 {:ok, to_bitcoin(amount, multiplier)}
 


### PR DESCRIPTION
We see these every time we parse an invoice in prod. 

```
warning: negative steps are not supported in String.slice/2, pass 2..-1//1 instead
  (elixir 1.16.1) lib/string.ex:2369: String.slice/2
  (bitcoinex 0.1.7) lib/lightning_network/invoice.ex:548: Bitcoinex.LightningNetwork.Invoice.parse_hrp/1
  (bitcoinex 0.1.7) lib/lightning_network/invoice.ex:66: Bitcoinex.LightningNetwork.Invoice.decode/1
  (alto_core 0.1.0) lib/alto_core/lightning/lightning.ex:46: AltoCore.Lightning.decode_invoice/1
  (alto_core 0.1.0) lib/alto_core/btc_transactions/tx_ln_out.ex:178: AltoCore.BtcTransactions.TxLnOut.validate_bolt11/1
  (alto_core 0.1.0) lib/alto_core/btc_transactions/tx_ln_out.ex:89: AltoCore.BtcTransactions.TxLnOut.changeset/3
```