### PR TITLE
Remove Timex dependency

### DIFF
--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -99,7 +99,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   @spec expires_at(Bitcoinex.LightningNetwork.Invoice.t()) :: DateTime.t()
   def expires_at(%__MODULE__{} = invoice) do
     expiry = invoice.expiry
-    Timex.from_unix(invoice.timestamp + expiry, :second)
+    DateTime.from_unix!(invoice.timestamp + expiry)
   end
 
   # checking some invariant for invoice

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,6 @@ defmodule Bitcoinex.MixProject do
       {:excoveralls, "~> 0.10", only: :test},
       {:mix_test_watch, "~> 1.1", only: :dev, runtime: false},
       {:stream_data, "~> 0.1", only: :test},
-      {:timex, "~> 3.1"},
       {:decimal, "~> 1.0 or ~> 2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:benchee, ">= 1.0.0", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -27,7 +27,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
-  "timex": {:hex, :timex, "3.7.9", "790cdfc4acfce434e442f98c02ea6d84d0239073bfd668968f82ac63e9a6788d", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 1.1", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm", "64691582e5bb87130f721fc709acfb70f24405833998fabf35be968984860ce1"},
-  "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -523,7 +523,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
     } do
       for {_valid_encoded_invoice, invoice} <- invoices do
         expires_at = Invoice.expires_at(invoice)
-        assert Timex.to_unix(expires_at) - (invoice.expiry || 3600) == invoice.timestamp
+        assert DateTime.to_unix(expires_at) - (invoice.expiry || 3600) == invoice.timestamp
       end
     end
   end


### PR DESCRIPTION
It's only used for `from_unix` and `to_unix`, both of which are supported by the standard `DateTime`.