### PR TITLE
style: convert camelCase to snake_case across the project

### DIFF
--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -418,8 +418,9 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
         case Bech32.convert_bits(rest, 5, 8, false) do
           {:ok, script_hash} ->
             {:ok,
-             Bitcoinex.Address.encode(
-               script_hash |> :binary.list_to_bin(),
+             script_hash
+             |> :binary.list_to_bin()
+             |> Bitcoinex.Address.encode(
                network,
                :p2sh
              )}

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -142,7 +142,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   defp validate_and_parse_signature_data(destination, hrp, invoice_data, signature_data)
        when is_list(invoice_data) and is_list(signature_data) do
     with {:ok, signature_data_in_byte} <- Bech32.convert_bits(signature_data, 5, 8),
-         {signature, [recoveryId]} = split_at(signature_data_in_byte, -1),
+         {signature, [recovery_id]} = split_at(signature_data_in_byte, -1),
          {:ok, invoice_data_in_byte} <- Bech32.convert_bits(invoice_data, 5, 8) do
       to_sign = (hrp |> :erlang.binary_to_list()) ++ invoice_data_in_byte
       signature = signature |> byte_list_to_binary
@@ -151,7 +151,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       # TODO if destination exist from tagged field, we dun need to recover but to verify it with signature
       # but that require convert lg sig before using secp256k1 to verify it
       # TODO refactor too nested
-      case Bitcoinex.Secp256k1.Ecdsa.ecdsa_recover_compact(hash, signature, recoveryId) do
+      case Bitcoinex.Secp256k1.Ecdsa.ecdsa_recover_compact(hash, signature, recovery_id) do
         {:ok, pubkey} ->
           if is_nil(destination) or destination == pubkey do
             {:ok, pubkey}
@@ -401,10 +401,11 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
 
       17 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
-          {:ok, pubKeyHash} ->
+          {:ok, pub_key_hash} ->
             {:ok,
-             Bitcoinex.Address.encode(
-               pubKeyHash |> :binary.list_to_bin(),
+             pub_key_hash
+             |> :binary.list_to_bin()
+             |> Bitcoinex.Address.encode(
                network,
                :p2pkh
              )}
@@ -415,10 +416,10 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
 
       18 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
-          {:ok, scriptHash} ->
+          {:ok, script_hash} ->
             {:ok,
              Bitcoinex.Address.encode(
-               scriptHash |> :binary.list_to_bin(),
+               script_hash |> :binary.list_to_bin(),
                network,
                :p2sh
              )}

--- a/lib/secp256k1/math.ex
+++ b/lib/secp256k1/math.ex
@@ -70,9 +70,9 @@ defmodule Bitcoinex.Secp256k1.Math do
   """
   def multiply(p, n) when is_point(p) and is_integer(n) do
     p
-    |> toJacobian()
-    |> jacobianMultiply(n)
-    |> fromJacobian()
+    |> to_jacobian()
+    |> jacobian_multiply(n)
+    |> from_jacobian()
   end
 
   @doc """
@@ -80,17 +80,19 @@ defmodule Bitcoinex.Secp256k1.Math do
   does jacobian addition to return resulting point.
   """
   def add(p, q) when is_point(p) and is_point(q) do
-    jacobianAdd(toJacobian(p), toJacobian(q))
-    |> fromJacobian()
+    p
+    |> to_jacobian()
+    |> jacobian_add(to_jacobian(q))
+    |> from_jacobian()
   end
 
   # Convert our point P to jacobian coordinates.
-  defp toJacobian(p) do
+  defp to_jacobian(p) do
     %Point{x: p.x, y: p.y, z: 1}
   end
 
   # Convert our jacobian coordinates to a point P on secp256k1 curve.
-  defp fromJacobian(p) do
+  defp from_jacobian(p) do
     z = inv(p.z, Params.curve().p)
 
     %Point{
@@ -110,7 +112,7 @@ defmodule Bitcoinex.Secp256k1.Math do
   # double Point P to get point P + P
   # We use the dbl-1998-cmo-2 doubling formula.
   # For reference, http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html.
-  defp jacobianDouble(p) do
+  defp jacobian_double(p) do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 0}
     else
@@ -159,7 +161,7 @@ defmodule Bitcoinex.Secp256k1.Math do
   # add points P and Q to get P + Q
   # We use the add-1998-cmo-2 addition formula.
   # For reference, http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian.html.
-  defp jacobianAdd(p, q) do
+  defp jacobian_add(p, q) do
     if p.y == 0 do
       q
     else
@@ -190,7 +192,7 @@ defmodule Bitcoinex.Secp256k1.Math do
           if s1 != s2 do
             %Point{x: 0, y: 0, z: 1}
           else
-            jacobianDouble(p)
+            jacobian_double(p)
           end
         else
           # H = U2 - U1
@@ -236,11 +238,11 @@ defmodule Bitcoinex.Secp256k1.Math do
   end
 
   # multply point P with scalar n
-  defp jacobianMultiply(_p, n) when n == 0 do
+  defp jacobian_multiply(_p, n) when n == 0 do
     %Point{x: 0, y: 0, z: 1}
   end
 
-  defp jacobianMultiply(p, n) when n == 1 do
+  defp jacobian_multiply(p, n) when n == 1 do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
@@ -248,7 +250,7 @@ defmodule Bitcoinex.Secp256k1.Math do
     end
   end
 
-  defp jacobianMultiply(p, n)
+  defp jacobian_multiply(p, n)
        # This integer is n, the integer order of G for secp256k1.
        # Unfortunately cannot call Params.curve.n to get the curve order integer,
        # so instead, it is pasted it here.
@@ -259,26 +261,26 @@ defmodule Bitcoinex.Secp256k1.Math do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
-      jacobianMultiply(p, modulo(n, Params.curve().n))
+      jacobian_multiply(p, modulo(n, Params.curve().n))
     end
   end
 
-  defp jacobianMultiply(p, n) when rem(n, 2) == 0 do
+  defp jacobian_multiply(p, n) when rem(n, 2) == 0 do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
-      jacobianMultiply(p, div(n, 2))
-      |> jacobianDouble()
+      jacobian_multiply(p, div(n, 2))
+      |> jacobian_double()
     end
   end
 
-  defp jacobianMultiply(p, n) do
+  defp jacobian_multiply(p, n) do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
-      jacobianMultiply(p, div(n, 2))
-      |> jacobianDouble()
-      |> jacobianAdd(p)
+      jacobian_multiply(p, div(n, 2))
+      |> jacobian_double()
+      |> jacobian_add(p)
     end
   end
 end

--- a/lib/secp256k1/math.ex
+++ b/lib/secp256k1/math.ex
@@ -238,16 +238,12 @@ defmodule Bitcoinex.Secp256k1.Math do
   end
 
   # multply point P with scalar n
-  defp jacobian_multiply(_p, n) when n == 0 do
-    %Point{x: 0, y: 0, z: 1}
-  end
+  defp jacobian_multiply(_p, 0), do: %Point{x: 0, y: 0, z: 1}
 
-  defp jacobian_multiply(p, n) when n == 1 do
-    if p.y == 0 do
-      %Point{x: 0, y: 0, z: 1}
-    else
-      p
-    end
+  defp jacobian_multiply(p, 1) do
+    if p.y == 0,
+      do: %Point{x: 0, y: 0, z: 1},
+      else: p
   end
 
   defp jacobian_multiply(p, n)
@@ -269,7 +265,8 @@ defmodule Bitcoinex.Secp256k1.Math do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
-      jacobian_multiply(p, div(n, 2))
+      p
+      |> jacobian_multiply(div(n, 2))
       |> jacobian_double()
     end
   end
@@ -278,7 +275,8 @@ defmodule Bitcoinex.Secp256k1.Math do
     if p.y == 0 do
       %Point{x: 0, y: 0, z: 1}
     else
-      jacobian_multiply(p, div(n, 2))
+      p
+      |> jacobian_multiply(div(n, 2))
       |> jacobian_double()
       |> jacobian_add(p)
     end


### PR DESCRIPTION
Convert variable naming from camelCase to snake_case

This PR updates variable naming across the project to follow Elixir naming conventions. All camelCase variables/functions have been converted to snake_case format for better consistency with Elixir style guide and community standards.

Changes:
- recoveryId -> recovery_id
- pubKeyHash -> pub_key_hash
- toJacobian -> to_jacobian
- etc.

No functional changes, only style improvements