### PR TITLE
TK1: BIP341 taproot key-path spend support

### DIFF
--- a/lib/script.ex
+++ b/lib/script.ex
@@ -7,7 +7,7 @@ defmodule Bitcoinex.Script do
 
   alias Bitcoinex.Secp256k1.Point
 
-  alias Bitcoinex.{Utils, Address, Segwit, Base58, Network}
+  alias Bitcoinex.{Utils, Address, Segwit, Base58, Network, Taproot}
 
   @wsh_length 32
   @tapkey_length 32
@@ -212,6 +212,17 @@ defmodule Bitcoinex.Script do
     script
     |> serialize_script()
     |> Base.encode16(case: :lower)
+  end
+
+  @doc """
+  	serialize_with_compact_size serializes the script and prepends its length
+  	as a compact-size unsigned integer, as used in BIP341/342 leaf and sighash
+  	serialization.
+  """
+  @spec serialize_with_compact_size(t()) :: binary
+  def serialize_with_compact_size(script = %__MODULE__{}) do
+    s = serialize_script(script)
+    Utils.serialize_compact_size_unsigned_int(byte_size(s)) <> s
   end
 
   @doc """
@@ -610,6 +621,38 @@ defmodule Bitcoinex.Script do
   def create_p2tr(<<pk::binary-size(@tapkey_length)>>), do: create_witness_scriptpubkey(1, pk)
   def create_p2tr(q = %Point{}), do: create_witness_scriptpubkey(1, Point.x_bytes(q))
   def create_p2tr(_), do: {:error, "public key must be #{@tapkey_length}-bytes"}
+
+  @doc """
+  	create_p2tr/2 creates a p2tr script from an UNTWEAKED internal key P and an
+  	optional `script_tree` (see `Bitcoinex.Taproot`). It applies the BIP341
+  	taproot tweak to derive the output key Q = P + H_TapTweak(P || merkle_root)·G
+  	and wraps Q in the witness scriptpubkey. Pass `script_tree: nil` for a
+  	key-path-only output.
+
+  	This differs from `create_p2tr/1`, which treats its argument as the
+  	already-tweaked output key Q. Silent-payment outputs are spent using the
+  	output key directly and therefore use `create_p2tr/1`, not this function.
+  """
+  @spec create_p2tr(Point.t() | binary | nil, Taproot.script_tree()) ::
+          {:ok, t()} | {:error, String.t()}
+  def create_p2tr(nil, nil), do: {:error, "script_tree or internal pubkey must be non-nil"}
+
+  def create_p2tr(p = %Point{}, script_tree), do: create_p2tr(Point.x_bytes(p), script_tree)
+
+  def create_p2tr(<<px::binary-size(@tapkey_length)>>, script_tree) do
+    {_, merkle_root} = Taproot.merkelize_script_tree(script_tree)
+
+    case Point.lift_x(px) do
+      {:error, msg} ->
+        {:error, msg}
+
+      {:ok, p} ->
+        case Taproot.tweak_pubkey(p, merkle_root) do
+          {:error, msg} -> {:error, msg}
+          q = %Point{} -> create_p2tr(q)
+        end
+    end
+  end
 
   @doc """
   	create_p2sh_p2wpkh creates a p2wsh script using the passed 20-byte public key hash

--- a/lib/taproot.ex
+++ b/lib/taproot.ex
@@ -40,7 +40,8 @@ defmodule Bitcoinex.Taproot do
       pk ->
         t = calculate_taptweak(pk, h)
 
-        if t > @n do
+        # BIP341: fail if t >= n (curve order)
+        if t >= @n do
           {:error, "invalid tweaked key"}
         else
           %PrivateKey{d: Math.modulo(sk.d + t, @n)}
@@ -57,7 +58,8 @@ defmodule Bitcoinex.Taproot do
   def tweak_pubkey(pk = %Point{}, h) do
     t = calculate_taptweak(pk, h)
 
-    if t > @n do
+    # BIP341: fail if t >= n (curve order)
+    if t >= @n do
       {:error, "invalid tweaked key"}
     else
       t_point = PrivateKey.to_point(t)

--- a/lib/taproot.ex
+++ b/lib/taproot.ex
@@ -1,0 +1,273 @@
+defmodule Bitcoinex.Taproot do
+  @moduledoc """
+    Implements BIP341 Taproot primitives: the key-path output tweak
+    (P -> Q), TapLeaf/TapBranch tagged hashes, script-tree merkelization,
+    and control-block construction/validation for script-path spends.
+
+    Key-path spends (including spending BIP86 outputs) use `tweak_privkey/2`
+    and `tweak_pubkey/2`. Script-path support (TapLeaf, control blocks,
+    `validate_taproot_scriptpath_spend/3`) is included for completeness but is
+    only partially exercised; script execution per BIP342 is not implemented.
+
+    See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+  """
+  alias Bitcoinex.Utils
+
+  alias Bitcoinex.Taproot
+  alias Bitcoinex.{Secp256k1, Script}
+  alias Bitcoinex.Secp256k1.{Math, Params, Point, PrivateKey}
+
+  @n Params.curve().n
+
+  @bip342_leaf_version 0xC0
+
+  @spec bip342_leaf_version :: 192
+  def bip342_leaf_version(), do: @bip342_leaf_version
+
+  @doc """
+    tweak_privkey applies the BIP341 taproot tweak to a private key, given the
+    merkle root `h` of the script tree (`<<>>` for a key-path-only output).
+    The key is first forced to even-Y per BIP341.
+  """
+  @spec tweak_privkey(PrivateKey.t(), binary) :: PrivateKey.t() | {:error, String.t()}
+  def tweak_privkey(sk0 = %PrivateKey{}, h) do
+    sk = Secp256k1.force_even_y(sk0)
+
+    case PrivateKey.to_point(sk) do
+      {:error, msg} ->
+        {:error, msg}
+
+      pk ->
+        t = calculate_taptweak(pk, h)
+
+        if t > @n do
+          {:error, "invalid tweaked key"}
+        else
+          %PrivateKey{d: Math.modulo(sk.d + t, @n)}
+        end
+    end
+  end
+
+  @doc """
+    tweak_pubkey applies the BIP341 taproot tweak to a public key, given the
+    merkle root `h` of the script tree (`<<>>` for a key-path-only output),
+    returning the output key Q.
+  """
+  @spec tweak_pubkey(Point.t(), binary) :: Point.t() | {:error, String.t()}
+  def tweak_pubkey(pk = %Point{}, h) do
+    t = calculate_taptweak(pk, h)
+
+    if t > @n do
+      {:error, "invalid tweaked key"}
+    else
+      t_point = PrivateKey.to_point(t)
+      Math.add(pk, t_point)
+    end
+  end
+
+  @spec calculate_taptweak(Point.t(), binary) :: non_neg_integer
+  def calculate_taptweak(pk = %Point{}, h) do
+    pk
+    |> Point.x_bytes()
+    |> Kernel.<>(h)
+    |> tagged_hash_taptweak()
+    |> :binary.decode_unsigned()
+  end
+
+  @spec tagged_hash_tapbranch(binary) :: <<_::256>>
+  def tagged_hash_tapbranch(br), do: Utils.tagged_hash("TapBranch", br)
+
+  @spec tagged_hash_taptweak(binary) :: <<_::256>>
+  def tagged_hash_taptweak(root), do: Utils.tagged_hash("TapTweak", root)
+
+  @spec tagged_hash_tapleaf(binary) :: <<_::256>>
+  def tagged_hash_tapleaf(leaf), do: Utils.tagged_hash("TapLeaf", leaf)
+
+  @spec tagged_hash_tapsighash(binary) :: <<_::256>>
+  def tagged_hash_tapsighash(sigmsg), do: Utils.tagged_hash("TapSighash", sigmsg)
+
+  defmodule TapLeaf do
+    @moduledoc """
+      TapLeaf represents a leaf of a Taproot Merkle tree. A leaf
+      contains a version and a Script.
+    """
+    alias Bitcoinex.Script
+    alias Bitcoinex.Taproot
+
+    @type t :: %__MODULE__{
+            version: non_neg_integer(),
+            script: Script.t()
+          }
+    @enforce_keys [
+      :version,
+      :script
+    ]
+    defstruct [
+      :version,
+      :script
+    ]
+
+    @doc """
+      new constructs a TapLeaf from a leaf_version and Script.
+    """
+    @spec new(non_neg_integer(), Script.t()) :: t()
+    def new(leaf_version, script = %Script{}) do
+      %__MODULE__{version: leaf_version, script: script}
+    end
+
+    @spec from_string(non_neg_integer(), String.t()) :: t()
+    def from_string(leaf_version, script_hex) do
+      {:ok, script} = Script.parse_script(script_hex)
+      new(leaf_version, script)
+    end
+
+    @doc """
+      serialize returns a binary concatenation of the leaf_version and the
+      compact-size-prefixed Script.
+    """
+    @spec serialize(t()) :: binary
+    def serialize(%__MODULE__{version: v, script: s}),
+      do: :binary.encode_unsigned(v) <> Script.serialize_with_compact_size(s)
+
+    @doc """
+      hash returns the Hash_TapLeaf of the serialized TapLeaf
+    """
+    @spec hash(t()) :: <<_::256>>
+    def hash(tapleaf = %__MODULE__{}), do: serialize(tapleaf) |> Taproot.tagged_hash_tapleaf()
+  end
+
+  @typedoc """
+    script_tree represents a Taproot Script Merkle Tree. Leaves are represented by TapLeaf structs
+    while branches are {script_tree, script_tree}. Since we sort based on hash at each level,
+    left vs right branches are irrelevant. An empty tree is represented by nil.
+  """
+  @type script_tree :: Taproot.TapLeaf.t() | {script_tree(), script_tree()} | nil
+
+  @doc """
+    merkelize_script_tree takes a script_tree (either nil, a TapLeaf, or a tuple of two script_trees)
+    and constructs the root node. It returns {root_node, hash}. The hash is `<<>>` if the script_tree is empty.
+    defined in BIP341 https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+  """
+  @spec merkelize_script_tree(script_tree()) :: {list({TapLeaf.t(), binary}) | nil, binary}
+  def merkelize_script_tree(nil), do: {nil, <<>>}
+
+  def merkelize_script_tree(leaf = %TapLeaf{}) do
+    hash = TapLeaf.hash(leaf)
+
+    {[{leaf, <<>>}], hash}
+  end
+
+  def merkelize_script_tree({left, right}) do
+    {{l_branches, l_hash}, {r_branches, r_hash}} =
+      {merkelize_script_tree(left), merkelize_script_tree(right)}
+
+    # cross-mix the right hash with left branch and left hash with right branch
+    new_left = merkelize_branches(l_branches, r_hash)
+    new_right = merkelize_branches(r_branches, l_hash)
+
+    node = new_left ++ new_right
+
+    # combine the branches to form root node.
+    {l_hash, r_hash} = Utils.lexicographical_sort(l_hash, r_hash)
+    hash = tagged_hash_tapbranch(l_hash <> r_hash)
+    {node, hash}
+  end
+
+  defp merkelize_branches([], _), do: []
+
+  defp merkelize_branches([{leaf, c} | tail], hash) do
+    [{leaf, c <> hash} | merkelize_branches(tail, hash)]
+  end
+
+  @spec build_control_block(Point.t(), script_tree(), non_neg_integer()) :: binary
+  def build_control_block(p = %Point{}, script_tree, script_index) do
+    {tree, hash} = merkelize_script_tree(script_tree)
+    {tapleaf, merkle_path} = Enum.at(tree, script_index)
+    q = tweak_pubkey(p, hash)
+    q_parity = if Point.has_even_y(q), do: 0, else: 1
+
+    <<q_parity + tapleaf.version>> <> Point.x_bytes(p) <> merkle_path
+  end
+
+  @spec merkelize_control_block(<<_::256>>, binary) :: binary
+  def merkelize_control_block(<<k0::binary-size(32)>>, path) do
+    # Consume each 32-byte chunk of the rest of the control path, which are hashes of the merkle tree
+    path
+    |> :binary.bin_to_list()
+    |> Enum.chunk_every(32)
+    |> Enum.reduce(k0, fn e, k -> merkelize_path(:binary.list_to_bin(e), k) end)
+  end
+
+  defp merkelize_path(<<e::binary-size(32)>>, <<k::binary-size(32)>>) do
+    {l, r} = Utils.lexicographical_sort(e, k)
+    tagged_hash_tapbranch(l <> r)
+  end
+
+  @doc """
+    validate_taproot_scriptpath_spend DOES NOT validate the actual script according to BIP342.
+    It only validates the BIP341 rules around how a scriptPath spend works.
+    See: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules
+  """
+  @spec validate_taproot_scriptpath_spend(Point.t(), binary, binary) ::
+          bool | {:error, String.t()}
+  def validate_taproot_scriptpath_spend(
+        q_point = %Point{},
+        script,
+        <<c::binary-size(1)>> <> <<p::binary-size(32)>> <> path
+      ) do
+    leaf_version = extract_leaf_version(c)
+
+    k0 =
+      tagged_hash_tapleaf(
+        leaf_version <> Utils.serialize_compact_size_unsigned_int(byte_size(script)) <> script
+      )
+
+    k = merkelize_control_block(k0, path)
+    # t is tweak
+    t = tagged_hash_taptweak(p <> k) |> :binary.decode_unsigned()
+
+    case {PrivateKey.to_point(t), Point.lift_x(p)} do
+      {{:error, _}, _} ->
+        {:error, "control block yielded invalid tweak"}
+
+      {_, {:error, _}} ->
+        {:error, "failed to parse point Q"}
+
+      {tk, {:ok, pk}} ->
+        validate_q(q_point, Math.add(pk, tk), c)
+    end
+  end
+
+  defp validate_q(given_q = %Point{}, calculated_q = %Point{}, <<c::binary-size(1)>>) do
+    q_parity = extract_q_parity(c)
+
+    cond do
+      q_parity != Point.has_even_y(given_q) ->
+        {:error, "incorrect Q parity"}
+
+      given_q.x != calculated_q.x ->
+        {:error, "Q points do not match"}
+
+      true ->
+        true
+    end
+  end
+
+  @spec extract_leaf_version(<<_::8>>) :: binary
+  defp extract_leaf_version(<<c::binary-size(1)>>) do
+    c
+    |> :binary.decode_unsigned()
+    |> Bitwise.band(0xFE)
+    |> :binary.encode_unsigned()
+  end
+
+  @spec extract_q_parity(<<_::8>>) :: bool
+  defp extract_q_parity(<<c::binary-size(1)>>) do
+    q_mod2 =
+      c
+      |> :binary.decode_unsigned()
+      |> Bitwise.band(1)
+
+    q_mod2 == 0
+  end
+end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -8,6 +8,7 @@ defmodule Bitcoinex.Transaction do
   alias Bitcoinex.Transaction.Out
   alias Bitcoinex.Transaction.Witness
   alias Bitcoinex.Utils
+  alias Bitcoinex.Taproot
   alias Bitcoinex.Transaction.Utils, as: TxUtils
 
   @type t() :: %__MODULE__{
@@ -25,6 +26,31 @@ defmodule Bitcoinex.Transaction do
     :witnesses,
     :lock_time
   ]
+
+  @sighash_default 0x00
+  @sighash_all 0x01
+  @sighash_none 0x02
+  @sighash_single 0x03
+  @sighash_anyonecanpay 0x80
+  @sighash_anyonecanpay_all 0x81
+  @sighash_anyonecanpay_none 0x82
+  @sighash_anyonecanpay_single 0x83
+
+  @valid_sighash_flags [
+    @sighash_default,
+    @sighash_all,
+    @sighash_none,
+    @sighash_single,
+    @sighash_anyonecanpay_all,
+    @sighash_anyonecanpay_none,
+    @sighash_anyonecanpay_single
+  ]
+
+  @doc """
+    valid_sighash_flags returns the list of sighash flags accepted by `bip341_sighash/7`.
+  """
+  @spec valid_sighash_flags() :: list(non_neg_integer())
+  def valid_sighash_flags(), do: @valid_sighash_flags
 
   @doc """
     Returns the TxID of the given tranasction.
@@ -103,6 +129,264 @@ defmodule Bitcoinex.Transaction do
          lock_time: lock_time
        }}
     end
+  end
+
+  @doc """
+    bip341_sighash computes the BIP341 signature hash (the tagged TapSighash) for
+    the input at `input_idx`.
+
+    `hash_type` is one of `valid_sighash_flags/0`. `ext_flag` is 0 for key-path
+    spends and 1 for tapscript (BIP342) spends. `prev_amounts` and
+    `prev_scriptpubkeys` are the amounts (in sats) and compact-size-prefixed
+    scriptpubkeys of ALL inputs being spent, in input order (see
+    `Bitcoinex.Script.serialize_with_compact_size/1`).
+
+    For a tapscript spend pass `opts: [tapleaf: %Taproot.TapLeaf{}]`.
+
+    See https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#signature-validation-rules
+  """
+  @spec bip341_sighash(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          list(non_neg_integer()),
+          list(binary()),
+          keyword()
+        ) :: <<_::256>> | {:error, String.t()}
+  def bip341_sighash(
+        tx = %__MODULE__{},
+        hash_type,
+        ext_flag,
+        input_idx,
+        prev_amounts,
+        prev_scriptpubkeys,
+        opts \\ []
+      ) do
+    case bip341_sigmsg(
+           tx,
+           hash_type,
+           ext_flag,
+           input_idx,
+           prev_amounts,
+           prev_scriptpubkeys,
+           opts
+         ) do
+      {:error, msg} -> {:error, msg}
+      sigmsg -> Taproot.tagged_hash_tapsighash(sigmsg)
+    end
+  end
+
+  @doc """
+    bip341_sigmsg builds the BIP341 signature message (the preimage hashed by
+    `bip341_sighash/7`).
+  """
+  @spec bip341_sigmsg(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          list(non_neg_integer()),
+          list(binary()),
+          keyword()
+        ) :: binary | {:error, String.t()}
+  def bip341_sigmsg(
+        tx,
+        hash_type,
+        ext_flag,
+        input_idx,
+        prev_amounts,
+        prev_scriptpubkeys,
+        opts \\ []
+      )
+
+  def bip341_sigmsg(_, _, ext_flag, _, _, _, _) when ext_flag < 0 or ext_flag > 127,
+    do: {:error, "ext_flag out of range 0-127"}
+
+  def bip341_sigmsg(_, hash_type, _, _, _, _, _) when hash_type not in @valid_sighash_flags,
+    do: {:error, "invalid sighash flag"}
+
+  def bip341_sigmsg(
+        tx = %__MODULE__{},
+        hash_type,
+        ext_flag,
+        input_idx,
+        prev_amounts,
+        prev_scriptpubkeys,
+        opts
+      ) do
+    hash_byte = :binary.encode_unsigned(hash_type)
+
+    tx_data = bip341_tx_data(tx, hash_type, prev_amounts, prev_scriptpubkeys)
+
+    input_data =
+      bip341_input_data(
+        tx,
+        hash_type,
+        ext_flag,
+        input_idx,
+        Enum.at(prev_amounts, input_idx),
+        Enum.at(prev_scriptpubkeys, input_idx)
+      )
+
+    output_data = bip341_output_data(tx, input_idx, hash_type)
+
+    ext =
+      case Keyword.get(opts, :tapleaf, nil) do
+        tl = %Taproot.TapLeaf{} -> sigmsg_extension(ext_flag, tl)
+        nil -> sigmsg_extension(ext_flag)
+      end
+
+    <<0>> <> hash_byte <> tx_data <> input_data <> output_data <> ext
+  end
+
+  # The results of this function are constant across all inputs of a tx and can be reused.
+  @spec bip341_tx_data(t(), non_neg_integer(), list(non_neg_integer()), list(binary())) :: binary
+  def bip341_tx_data(tx, hash_type, prev_amounts, prev_scriptpubkeys) do
+    version = <<tx.version::little-size(32)>>
+    lock_time = <<tx.lock_time::little-size(32)>>
+    acc = version <> lock_time
+
+    acc =
+      if !hash_type_is_anyonecanpay(hash_type) do
+        acc <>
+          bip341_sha_prevouts(tx.inputs) <>
+          bip341_sha_amounts(prev_amounts) <>
+          bip341_sha_scriptpubkeys(prev_scriptpubkeys) <>
+          bip341_sha_sequences(tx.inputs)
+      else
+        acc
+      end
+
+    if !hash_type_is_none_or_single(hash_type) do
+      acc <> bip341_sha_outputs(tx.outputs)
+    else
+      acc
+    end
+  end
+
+  defp bip341_input_data(tx, hash_type, ext_flag, input_idx, prev_amount, prev_scriptpubkey) do
+    annex = get_annex(tx, input_idx)
+    spend_type = ext_flag * 2 + if annex == nil, do: 0, else: 1
+
+    input_commit =
+      if hash_type_is_anyonecanpay(hash_type) do
+        input = Enum.at(tx.inputs, input_idx)
+
+        In.serialize_prevout(input) <>
+          <<prev_amount::little-size(64)>> <>
+          prev_scriptpubkey <> <<input.sequence_no::little-size(32)>>
+      else
+        <<input_idx::little-size(32)>>
+      end
+
+    <<spend_type>> <> input_commit <> bip341_sha_annex(annex)
+  end
+
+  defp bip341_output_data(tx, input_idx, hash_type) do
+    if hash_type_is_single(hash_type) do
+      tx.outputs
+      |> Enum.at(input_idx)
+      |> List.wrap()
+      |> Out.serialize_outputs()
+      |> :erlang.list_to_binary()
+      |> Utils.sha256()
+    else
+      <<>>
+    end
+  end
+
+  @spec hash_type_is_anyonecanpay(non_neg_integer()) :: boolean
+  def hash_type_is_anyonecanpay(hash_type),
+    do: Bitwise.band(hash_type, @sighash_anyonecanpay) == @sighash_anyonecanpay
+
+  defp hash_type_is_none_or_single(hash_type) do
+    b = Bitwise.band(hash_type, 3)
+    b == @sighash_none || b == @sighash_single
+  end
+
+  defp hash_type_is_single(hash_type) do
+    Bitwise.band(hash_type, 3) == @sighash_single
+  end
+
+  @doc """
+    get_annex returns the BIP341 annex of the input at `input_idx`, or nil if
+    there is no witness/annex.
+  """
+  @spec get_annex(t(), non_neg_integer()) :: nil | binary | {:error, String.t()}
+  def get_annex(%__MODULE__{witnesses: nil}, _), do: nil
+  def get_annex(%__MODULE__{witnesses: []}, _), do: nil
+
+  def get_annex(%__MODULE__{witnesses: witnesses, inputs: inputs}, input_idx)
+      when input_idx >= 0 and input_idx < length(inputs) do
+    witnesses
+    |> Enum.at(input_idx)
+    |> Witness.get_annex()
+  end
+
+  def get_annex(_, _), do: {:error, "input index is out of range"}
+
+  @spec bip341_sha_prevouts(list(In.t())) :: <<_::256>>
+  def bip341_sha_prevouts(inputs) do
+    inputs
+    |> In.serialize_prevouts()
+    |> Utils.sha256()
+  end
+
+  @spec bip341_sha_amounts(list(non_neg_integer())) :: <<_::256>>
+  def bip341_sha_amounts(prev_amounts) do
+    prev_amounts
+    |> Enum.reduce(<<>>, fn amount, acc -> acc <> <<amount::little-size(64)>> end)
+    |> Utils.sha256()
+  end
+
+  @spec bip341_sha_scriptpubkeys(list(binary())) :: <<_::256>>
+  def bip341_sha_scriptpubkeys(prev_scriptpubkeys) do
+    prev_scriptpubkeys
+    |> Enum.reduce(<<>>, fn script, acc -> acc <> script end)
+    |> Utils.sha256()
+  end
+
+  @spec bip341_sha_sequences(list(In.t())) :: <<_::256>>
+  def bip341_sha_sequences(inputs) do
+    inputs
+    |> In.serialize_sequences()
+    |> Utils.sha256()
+  end
+
+  @spec bip341_sha_outputs(list(Out.t())) :: <<_::256>>
+  def bip341_sha_outputs(outputs) do
+    outputs
+    |> Out.serialize_outputs()
+    |> :erlang.list_to_binary()
+    |> Utils.sha256()
+  end
+
+  @spec bip341_sha_annex(nil | binary) :: binary
+  def bip341_sha_annex(nil), do: <<>>
+
+  def bip341_sha_annex(annex) do
+    annex
+    |> byte_size()
+    |> Utils.serialize_compact_size_unsigned_int()
+    |> Kernel.<>(annex)
+    |> Utils.sha256()
+  end
+
+  defp sigmsg_extension(0), do: <<>>
+
+  defp sigmsg_extension(1, tapleaf, last_executed_codesep_pos \\ 0xFFFFFFFF),
+    do: bip342_sigmsg_ext(tapleaf, last_executed_codesep_pos)
+
+  @doc """
+    bip342_sigmsg_ext builds the BIP342 tapscript signature-message extension.
+  """
+  @spec bip342_sigmsg_ext(Taproot.TapLeaf.t(), non_neg_integer()) :: binary
+  def bip342_sigmsg_ext(tapleaf = %Taproot.TapLeaf{}, last_executed_codesep_pos \\ 0xFFFFFFFF) do
+    key_version = 0x00
+
+    Taproot.TapLeaf.hash(tapleaf) <>
+      <<key_version>> <> <<last_executed_codesep_pos::little-size(32)>>
   end
 end
 
@@ -287,6 +571,27 @@ defmodule Bitcoinex.Transaction.Witness do
       stack_size - 1
     )
   end
+
+  @doc """
+    get_annex returns the BIP341 annex (the last witness item if it begins with
+    0x50 and the stack has at least two items), or nil otherwise.
+  """
+  @spec get_annex(t()) :: nil | binary
+  def get_annex(%__MODULE__{txinwitness: witnesses}) when not is_list(witnesses), do: nil
+  def get_annex(%__MODULE__{txinwitness: witnesses}) when length(witnesses) < 2, do: nil
+
+  def get_annex(%__MODULE__{txinwitness: witnesses}) do
+    last =
+      witnesses
+      |> Enum.reverse()
+      |> Enum.at(0)
+
+    case last do
+      # witness items are stored as lowercase hex strings; 0x50 == "50"
+      "50" <> _ -> last
+      _ -> nil
+    end
+  end
 end
 
 defmodule Bitcoinex.Transaction.In do
@@ -315,18 +620,48 @@ defmodule Bitcoinex.Transaction.In do
     serialize_input(inputs, [])
   end
 
+  @doc """
+    serialize_prevouts returns the concatenated 36-byte outpoints (prev_txid in
+    internal little-endian byte order followed by the 4-byte vout) of all inputs.
+  """
+  @spec serialize_prevouts(list(In.t())) :: binary
+  def serialize_prevouts(inputs) do
+    Enum.reduce(inputs, <<>>, fn input, acc -> acc <> serialize_prevout(input) end)
+  end
+
+  @doc """
+    serialize_prevout returns the 36-byte outpoint of a single input.
+  """
+  @spec serialize_prevout(In.t()) :: binary
+  def serialize_prevout(input) do
+    prev_txid_little_endian(input.prev_txid) <> <<input.prev_vout::little-size(32)>>
+  end
+
+  @doc """
+    serialize_sequences returns the concatenated 4-byte sequence numbers of all inputs.
+  """
+  @spec serialize_sequences(list(In.t())) :: binary
+  def serialize_sequences(inputs) do
+    Enum.reduce(inputs, <<>>, fn input, acc -> acc <> <<input.sequence_no::little-size(32)>> end)
+  end
+
+  # converts a display-order (big-endian) txid hex string into internal
+  # little-endian byte order, as used in tx and sighash serialization.
+  defp prev_txid_little_endian(prev_txid_hex) do
+    {:ok, raw} = Base.decode16(prev_txid_hex, case: :lower)
+
+    raw
+    |> :binary.decode_unsigned(:big)
+    |> :binary.encode_unsigned(:little)
+    |> Bitcoinex.Utils.pad(32, :trailing)
+  end
+
   defp serialize_input([], serialized_inputs), do: serialized_inputs
 
   defp serialize_input(inputs, serialized_inputs) do
     [input | inputs] = inputs
 
-    {:ok, prev_txid} = Base.decode16(input.prev_txid, case: :lower)
-
-    prev_txid =
-      prev_txid
-      |> :binary.decode_unsigned(:big)
-      |> :binary.encode_unsigned(:little)
-      |> Bitcoinex.Utils.pad(32, :trailing)
+    prev_txid = prev_txid_little_endian(input.prev_txid)
 
     {:ok, script_sig} = Base.decode16(input.script_sig, case: :lower)
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -107,4 +107,58 @@ defmodule Bitcoinex.Utils do
     |> Enum.map(fn {b0, b1} -> Bitwise.bxor(b0, b1) end)
     |> :binary.list_to_bin()
   end
+
+  @doc """
+    lexicographical_sort returns the two binaries in ascending byte order.
+  """
+  @spec lexicographical_sort(binary, binary) :: {binary, binary}
+  def lexicographical_sort(bin0, bin1) when is_binary(bin0) and is_binary(bin1) do
+    if lexicographical_cmp(:binary.bin_to_list(bin0), :binary.bin_to_list(bin1)) do
+      {bin0, bin1}
+    else
+      {bin1, bin0}
+    end
+  end
+
+  @doc """
+    lexicographical_cmp returns true if the first byte list is less than or equal
+    to the second in byte order. The equal case returns true.
+  """
+  @spec lexicographical_cmp(list(byte), list(byte)) :: boolean
+  def lexicographical_cmp([], []), do: true
+
+  def lexicographical_cmp([b0 | r0], [b1 | r1]) do
+    cond do
+      b0 == b1 ->
+        lexicographical_cmp(r0, r1)
+
+      b1 < b0 ->
+        # initial order was incorrect, must be swapped
+        false
+
+      true ->
+        # bin0, bin1 was the correct order
+        true
+    end
+  end
+
+  @doc """
+    Returns the serialized variable length (compact size) unsigned integer.
+  """
+  @spec serialize_compact_size_unsigned_int(non_neg_integer()) :: binary
+  def serialize_compact_size_unsigned_int(compact_size) do
+    cond do
+      compact_size >= 0 and compact_size <= 0xFC ->
+        <<compact_size::little-size(8)>>
+
+      compact_size <= 0xFFFF ->
+        <<0xFD>> <> <<compact_size::little-size(16)>>
+
+      compact_size <= 0xFFFFFFFF ->
+        <<0xFE>> <> <<compact_size::little-size(32)>>
+
+      compact_size <= 0xFFFFFFFFFFFFFFFF ->
+        <<0xFF>> <> <<compact_size::little-size(64)>>
+    end
+  end
 end

--- a/test/bip341_keyspend_vectors_test.exs
+++ b/test/bip341_keyspend_vectors_test.exs
@@ -127,4 +127,76 @@ defmodule Bitcoinex.Bip341KeyspendVectorsTest do
       assert Enum.sort(hash_types) == [0x00, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83]
     end
   end
+
+  describe "BIP341 fullySignedTx (end-to-end)" do
+    test "each key-path input's witness equals the expected witness signature" do
+      {:ok, tx} = Transaction.decode(@keypath["auxiliary"]["fullySignedTx"])
+
+      for spend <- @keypath["inputSpending"] do
+        idx = spend["given"]["txinIndex"]
+        expected_witness = spend["expected"]["witness"]
+        witness = Enum.at(tx.witnesses, idx)
+        assert witness.txinwitness == expected_witness, "witness mismatch at input #{idx}"
+      end
+    end
+  end
+
+  describe "bip341_sigmsg guards" do
+    test "rejects invalid sighash flags and out-of-range ext_flag" do
+      tx = unsigned_tx()
+      amounts = prev_amounts()
+      spks = prev_scriptpubkeys()
+
+      # 0x04 is not a valid sighash flag
+      assert {:error, _} = Transaction.bip341_sigmsg(tx, 0x04, 0, 0, amounts, spks)
+      # ext_flag must be 0..127
+      assert {:error, _} = Transaction.bip341_sigmsg(tx, 0x00, 128, 0, amounts, spks)
+      # and bip341_sighash propagates the error
+      assert {:error, _} = Transaction.bip341_sighash(tx, 0x04, 0, 0, amounts, spks)
+    end
+  end
+
+  describe "silent-payment spend path (no taproot tweak)" do
+    test "an output key used directly is spent by signing the key directly" do
+      # A silent-payment output places the output key directly in the
+      # scriptPubKey (no BIP341 taptweak). The spending key `d` comes from
+      # SilentPayments.spending_privkey/3; here we stand in a concrete `d` and
+      # assert the spend works WITHOUT Taproot.tweak_privkey.
+      {:ok, d} =
+        PrivateKey.new(0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF)
+
+      d = Bitcoinex.Secp256k1.force_even_y(d)
+      output_key = PrivateKey.to_point(d)
+
+      # SP output: wrap the output key directly via create_p2tr/1 (NOT /2)
+      {:ok, spk} = Script.create_p2tr(output_key)
+
+      tx = %Transaction{
+        version: 2,
+        inputs: [
+          %Transaction.In{
+            prev_txid: "a7b1d058aa1b82af168831044720b16766b5a99667720b1c110464cd125c466b",
+            prev_vout: 0,
+            script_sig: "",
+            sequence_no: 0xFFFFFFFF
+          }
+        ],
+        outputs: [%Transaction.Out{value: 9000, script_pub_key: Script.to_hex(spk)}],
+        lock_time: 0
+      }
+
+      sighash =
+        Transaction.bip341_sighash(tx, 0x00, 0, 0, [10000], [
+          Script.serialize_with_compact_size(spk)
+        ])
+
+      z = :binary.decode_unsigned(sighash)
+      {:ok, sig} = Schnorr.sign(d, z, 0)
+
+      # validator uses the even-Y lift of the x-only output key
+      {:ok, even_q} = Point.lift_x(output_key.x)
+      assert Schnorr.verify_signature(even_q, z, sig)
+      assert byte_size(Signature.serialize_signature(sig)) == 64
+    end
+  end
 end

--- a/test/bip341_keyspend_vectors_test.exs
+++ b/test/bip341_keyspend_vectors_test.exs
@@ -1,0 +1,130 @@
+defmodule Bitcoinex.Bip341KeyspendVectorsTest do
+  @moduledoc """
+  Drives the BIP341 key-path spend machinery (`Transaction.bip341_sighash/7`,
+  `Taproot.tweak_privkey/2`, and `Schnorr.sign/3`) with the official BIP341
+  wallet test vectors.
+
+  https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json
+
+  The checks are deliberately non-circular: sighashes/sigmsgs/tweaked keys are
+  compared against the BIP's own ground-truth values, and the signatures we
+  produce (as well as the vector's own expected witness signatures) are checked
+  with an INDEPENDENT verifier (`Schnorr.verify_signature/3`) against the
+  tweaked output key, never against our own signer.
+  """
+  use ExUnit.Case
+
+  alias Bitcoinex.{Script, Taproot, Transaction, Utils}
+  alias Bitcoinex.Secp256k1.{Point, PrivateKey, Schnorr, Signature}
+
+  @vectors_path Path.join([__DIR__, "data", "bip341_wallet_test_vectors.json"])
+  @vectors @vectors_path |> File.read!() |> Jason.decode!()
+  @keypath Enum.at(@vectors["keyPathSpending"], 0)
+
+  defp decode(hex), do: Base.decode16!(hex, case: :lower)
+
+  defp privkey(hex),
+    do: %PrivateKey{d: hex |> decode() |> :binary.decode_unsigned()}
+
+  # All inputs' amounts and compact-size-prefixed scriptpubkeys, in input order.
+  defp prev_amounts() do
+    Enum.map(@keypath["given"]["utxosSpent"], & &1["amountSats"])
+  end
+
+  defp prev_scriptpubkeys() do
+    Enum.map(@keypath["given"]["utxosSpent"], fn utxo ->
+      {:ok, s} = Script.parse_script(utxo["scriptPubKey"])
+      Script.serialize_with_compact_size(s)
+    end)
+  end
+
+  defp unsigned_tx() do
+    {:ok, tx} = Transaction.decode(@keypath["given"]["rawUnsignedTx"])
+    tx
+  end
+
+  describe "BIP341 precomputed sighash components" do
+    test "sha_prevouts / sha_amounts / sha_scriptpubkeys / sha_sequences / sha_outputs" do
+      tx = unsigned_tx()
+      inter = @keypath["intermediary"]
+
+      assert Transaction.bip341_sha_prevouts(tx.inputs) == decode(inter["hashPrevouts"])
+      assert Transaction.bip341_sha_amounts(prev_amounts()) == decode(inter["hashAmounts"])
+
+      assert Transaction.bip341_sha_scriptpubkeys(prev_scriptpubkeys()) ==
+               decode(inter["hashScriptPubkeys"])
+
+      assert Transaction.bip341_sha_sequences(tx.inputs) == decode(inter["hashSequences"])
+      assert Transaction.bip341_sha_outputs(tx.outputs) == decode(inter["hashOutputs"])
+    end
+  end
+
+  describe "BIP341 key-path inputSpending vectors" do
+    test "tweak_privkey, sigMsg, sigHash, and signature all match for every input" do
+      tx = unsigned_tx()
+      amounts = prev_amounts()
+      spks = prev_scriptpubkeys()
+
+      for spend <- @keypath["inputSpending"] do
+        given = spend["given"]
+        inter = spend["intermediary"]
+        idx = given["txinIndex"]
+        hash_type = given["hashType"]
+
+        merkle_root =
+          case given["merkleRoot"] do
+            nil -> <<>>
+            hex -> decode(hex)
+          end
+
+        # 1. tweaked private key matches the BIP ground truth
+        q_sk = Taproot.tweak_privkey(privkey(given["internalPrivkey"]), merkle_root)
+        assert Utils.int_to_big(q_sk.d, 32) == decode(inter["tweakedPrivkey"])
+
+        # 2. the full sigMsg preimage matches (transitively validates every sha_* component)
+        sigmsg = Transaction.bip341_sigmsg(tx, hash_type, 0, idx, amounts, spks)
+        assert sigmsg == decode(inter["sigMsg"])
+
+        # 3. the tagged TapSighash matches
+        sighash = Transaction.bip341_sighash(tx, hash_type, 0, idx, amounts, spks)
+        assert sighash == decode(inter["sigHash"])
+
+        z = :binary.decode_unsigned(sighash)
+        q_pk = PrivateKey.to_point(q_sk)
+        # a validator always uses the even-Y lift of the x-only output key
+        {:ok, even_q} = Point.lift_x(q_pk.x)
+
+        # 4. the signature WE produce verifies under an independent verifier
+        {:ok, our_sig} = Schnorr.sign(q_sk, z, 0)
+        assert Schnorr.verify_signature(even_q, z, our_sig)
+
+        # 5. the BIP's expected witness signature also verifies against our sighash.
+        #    A 65-byte witness carries an explicit sighash flag byte (non-DEFAULT);
+        #    DEFAULT (0x00) is a bare 64-byte signature.
+        expected = decode(Enum.at(spend["expected"]["witness"], 0))
+
+        sig_bytes =
+          case byte_size(expected) do
+            64 ->
+              assert hash_type == 0x00
+              expected
+
+            65 ->
+              <<sig::binary-size(64), flag>> = expected
+              assert flag == hash_type
+              sig
+          end
+
+        {:ok, vector_sig} = Signature.parse_signature(sig_bytes)
+        assert Schnorr.verify_signature(even_q, z, vector_sig)
+      end
+    end
+
+    test "covers all 7 inputs and every sighash flag type" do
+      hash_types = Enum.map(@keypath["inputSpending"], & &1["given"]["hashType"])
+      assert length(hash_types) == 7
+      # DEFAULT, ALL, NONE, SINGLE, and the three ANYONECANPAY variants
+      assert Enum.sort(hash_types) == [0x00, 0x01, 0x02, 0x03, 0x81, 0x82, 0x83]
+    end
+  end
+end

--- a/test/data/bip341_wallet_test_vectors.json
+++ b/test/data/bip341_wallet_test_vectors.json
@@ -1,0 +1,452 @@
+{
+    "version": 1,
+    "scriptPubKey": [
+        {
+            "given": {
+                "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                "scriptTree": null
+            },
+            "intermediary": {
+                "merkleRoot": null,
+                "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                "tweakedPubkey": "53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343"
+            },
+            "expected": {
+                "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                "bip350Address": "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5"
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21"
+                ],
+                "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                "tweakedPubkey": "147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3"
+            },
+            "expected": {
+                "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                "bip350Address": "bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586",
+                "scriptPathControlBlocks": [
+                    "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b"
+                ],
+                "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                "tweakedPubkey": "e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e"
+            },
+            "expected": {
+                "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                "bip350Address": "bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5",
+                "scriptPathControlBlocks": [
+                    "c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "06424950333431",
+                        "leafVersion": 250
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+                    "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a"
+                ],
+                "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                "tweakedPubkey": "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5"
+            },
+            "expected": {
+                "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                "bip350Address": "bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm",
+                "scriptPathControlBlocks": [
+                    "c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+                    "faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "07546170726f6f74",
+                        "leafVersion": 192
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89",
+                    "2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb"
+                ],
+                "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                "tweakedPubkey": "77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220"
+            },
+            "expected": {
+                "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                "bip350Address": "bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq",
+                "scriptPathControlBlocks": [
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb",
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c",
+                    "9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6"
+                ],
+                "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                "tweakedPubkey": "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605"
+            },
+            "expected": {
+                "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                "bip350Address": "bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e",
+                "scriptPathControlBlocks": [
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711",
+                    "d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7"
+                ],
+                "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                "tweakedPubkey": "75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831"
+            },
+            "expected": {
+                "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                "bip350Address": "bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe",
+                "scriptPathControlBlocks": [
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
+                ]
+            }
+        }
+    ],
+    "keyPathSpending": [
+        {
+            "given": {
+                "rawUnsignedTx": "02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d",
+                "utxosSpent": [
+                    {
+                        "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                        "amountSats": 420000000
+                    },
+                    {
+                        "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                        "amountSats": 462000000
+                    },
+                    {
+                        "scriptPubKey": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
+                        "amountSats": 294000000
+                    },
+                    {
+                        "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                        "amountSats": 504000000
+                    },
+                    {
+                        "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                        "amountSats": 630000000
+                    },
+                    {
+                        "scriptPubKey": "00147dd65592d0ab2fe0d0257d571abf032cd9db93dc",
+                        "amountSats": 378000000
+                    },
+                    {
+                        "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                        "amountSats": 672000000
+                    },
+                    {
+                        "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                        "amountSats": 546000000
+                    },
+                    {
+                        "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                        "amountSats": 588000000
+                    }
+                ]
+            },
+            "intermediary": {
+                "hashAmounts": "58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6",
+                "hashOutputs": "a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5",
+                "hashPrevouts": "e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f",
+                "hashScriptPubkeys": "23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21",
+                "hashSequences": "18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e"
+            },
+            "inputSpending": [
+                {
+                    "given": {
+                        "txinIndex": 0,
+                        "internalPrivkey": "6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa",
+                        "merkleRoot": null,
+                        "hashType": 3
+                    },
+                    "intermediary": {
+                        "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                        "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                        "tweakedPrivkey": "2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9",
+                        "sigMsg": "0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 1,
+                        "internalPrivkey": "1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f",
+                        "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                        "hashType": 131
+                    },
+                    "intermediary": {
+                        "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                        "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                        "tweakedPrivkey": "ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080",
+                        "sigMsg": "0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d",
+                        "precomputedUsed": [],
+                        "sigHash": "325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d"
+                    },
+                    "expected": {
+                        "witness": [
+                            "052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 3,
+                        "internalPrivkey": "d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64",
+                        "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                        "hashType": 1
+                    },
+                    "intermediary": {
+                        "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                        "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                        "tweakedPrivkey": "97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d",
+                        "sigMsg": "0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 4,
+                        "internalPrivkey": "f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e",
+                        "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                        "hashType": 0
+                    },
+                    "intermediary": {
+                        "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                        "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                        "tweakedPrivkey": "a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501",
+                        "sigMsg": "0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef"
+                    },
+                    "expected": {
+                        "witness": [
+                            "b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 6,
+                        "internalPrivkey": "415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8",
+                        "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                        "hashType": 2
+                    },
+                    "intermediary": {
+                        "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                        "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                        "tweakedPrivkey": "241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901",
+                        "sigMsg": "0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85"
+                    },
+                    "expected": {
+                        "witness": [
+                            "a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 7,
+                        "internalPrivkey": "c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103",
+                        "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                        "hashType": 130
+                    },
+                    "intermediary": {
+                        "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                        "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                        "tweakedPrivkey": "65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b",
+                        "sigMsg": "0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff",
+                        "precomputedUsed": [],
+                        "sigHash": "cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 8,
+                        "internalPrivkey": "77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa",
+                        "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                        "hashType": 129
+                    },
+                    "intermediary": {
+                        "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                        "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                        "tweakedPrivkey": "ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5",
+                        "sigMsg": "0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff",
+                        "precomputedUsed": [
+                            "hashOutputs"
+                        ],
+                        "sigHash": "cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2"
+                    },
+                    "expected": {
+                        "witness": [
+                            "bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981"
+                        ]
+                    }
+                }
+            ],
+            "auxiliary": {
+                "fullySignedTx": "020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d"
+            }
+        }
+    ]
+}

--- a/test/taproot_test.exs
+++ b/test/taproot_test.exs
@@ -1,0 +1,92 @@
+defmodule Bitcoinex.TaprootTest do
+  use ExUnit.Case
+  doctest Bitcoinex.Taproot
+
+  alias Bitcoinex.{Script, Taproot}
+  alias Bitcoinex.Secp256k1.Point
+
+  # Official BIP341 wallet test vectors:
+  # https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json
+  @vectors_path Path.join([__DIR__, "data", "bip341_wallet_test_vectors.json"])
+  @vectors @vectors_path |> File.read!() |> Jason.decode!()
+  @spk_vectors @vectors["scriptPubKey"]
+
+  defp decode(hex), do: Base.decode16!(hex, case: :lower)
+
+  # Build a Taproot.script_tree from the JSON `scriptTree` field:
+  # null -> nil, leaf object -> TapLeaf, [a, b] -> {tree(a), tree(b)}.
+  defp build_tree(nil), do: nil
+
+  defp build_tree(%{"leafVersion" => v, "script" => s}),
+    do: Taproot.TapLeaf.from_string(v, s)
+
+  defp build_tree([a, b]), do: {build_tree(a), build_tree(b)}
+
+  defp expected_root(nil), do: <<>>
+  defp expected_root(hex), do: decode(hex)
+
+  describe "BIP341 scriptPubKey test vectors" do
+    test "merkelize_script_tree/1 computes the BIP341 merkle root" do
+      for {e, i} <- Enum.with_index(@spk_vectors) do
+        tree = build_tree(e["given"]["scriptTree"])
+        {_, root} = Taproot.merkelize_script_tree(tree)
+
+        assert root == expected_root(e["intermediary"]["merkleRoot"]),
+               "merkle root mismatch for scriptPubKey vector #{i}"
+      end
+    end
+
+    test "tweak_pubkey/2 produces the expected tweaked output key" do
+      for {e, i} <- Enum.with_index(@spk_vectors) do
+        {:ok, p} = Point.lift_x(decode(e["given"]["internalPubkey"]))
+        root = expected_root(e["intermediary"]["merkleRoot"])
+        q = Taproot.tweak_pubkey(p, root)
+
+        assert Point.x_bytes(q) == decode(e["intermediary"]["tweakedPubkey"]),
+               "tweaked pubkey mismatch for scriptPubKey vector #{i}"
+      end
+    end
+
+    test "Script.create_p2tr/2 builds the expected scriptPubKey from internal key + tree" do
+      for {e, i} <- Enum.with_index(@spk_vectors) do
+        {:ok, p} = Point.lift_x(decode(e["given"]["internalPubkey"]))
+        tree = build_tree(e["given"]["scriptTree"])
+        {:ok, spk} = Script.create_p2tr(p, tree)
+
+        assert Script.to_hex(spk) == e["expected"]["scriptPubKey"],
+               "scriptPubKey mismatch for vector #{i}"
+      end
+    end
+
+    test "build_control_block/3 produces blocks that validate_taproot_scriptpath_spend accepts" do
+      # Exercises the BIP341 script-path control-block round trip for the
+      # tree-bearing vectors (construction and validation are independent paths).
+      for {e, i} <- Enum.with_index(@spk_vectors), e["given"]["scriptTree"] != nil do
+        {:ok, p} = Point.lift_x(decode(e["given"]["internalPubkey"]))
+        tree = build_tree(e["given"]["scriptTree"])
+        {nodes, root} = Taproot.merkelize_script_tree(tree)
+        q = Taproot.tweak_pubkey(p, root)
+
+        for {{leaf, _path}, idx} <- Enum.with_index(nodes) do
+          control_block = Taproot.build_control_block(p, tree, idx)
+          script_bytes = Script.serialize_script(leaf.script)
+
+          assert Taproot.validate_taproot_scriptpath_spend(q, script_bytes, control_block) ==
+                   true,
+                 "control block #{idx} failed validation for vector #{i}"
+        end
+      end
+    end
+  end
+
+  describe "calculate_taptweak/2" do
+    test "key-path-only tweak commits to an empty merkle root" do
+      # vector 0 has scriptTree == null (key-path only)
+      e = Enum.at(@spk_vectors, 0)
+      {:ok, p} = Point.lift_x(decode(e["given"]["internalPubkey"]))
+
+      tweak = Taproot.calculate_taptweak(p, <<>>)
+      assert Bitcoinex.Utils.int_to_big(tweak, 32) == decode(e["intermediary"]["tweak"])
+    end
+  end
+end

--- a/test/taproot_test.exs
+++ b/test/taproot_test.exs
@@ -58,9 +58,18 @@ defmodule Bitcoinex.TaprootTest do
       end
     end
 
-    test "build_control_block/3 produces blocks that validate_taproot_scriptpath_spend accepts" do
-      # Exercises the BIP341 script-path control-block round trip for the
-      # tree-bearing vectors (construction and validation are independent paths).
+    test "the scriptPubKey produces the expected bip350 (bech32m) address" do
+      for {e, i} <- Enum.with_index(@spk_vectors) do
+        {:ok, spk} = Script.parse_script(e["expected"]["scriptPubKey"])
+        {:ok, addr} = Script.to_address(spk, :mainnet)
+        assert addr == e["expected"]["bip350Address"], "address mismatch for vector #{i}"
+      end
+    end
+
+    test "TapLeaf.hash/1 and build_control_block/3 match the BIP341 ground-truth values" do
+      # Non-circular: leaf hashes and control blocks are compared to the
+      # vector's own `leafHashes` / `scriptPathControlBlocks`, and the produced
+      # control block is also checked against the independent validator.
       for {e, i} <- Enum.with_index(@spk_vectors), e["given"]["scriptTree"] != nil do
         {:ok, p} = Point.lift_x(decode(e["given"]["internalPubkey"]))
         tree = build_tree(e["given"]["scriptTree"])
@@ -68,7 +77,16 @@ defmodule Bitcoinex.TaprootTest do
         q = Taproot.tweak_pubkey(p, root)
 
         for {{leaf, _path}, idx} <- Enum.with_index(nodes) do
+          assert Taproot.TapLeaf.hash(leaf) ==
+                   decode(Enum.at(e["intermediary"]["leafHashes"], idx)),
+                 "leaf hash #{idx} mismatch for vector #{i}"
+
           control_block = Taproot.build_control_block(p, tree, idx)
+
+          assert control_block == decode(Enum.at(e["expected"]["scriptPathControlBlocks"], idx)),
+                 "control block #{idx} mismatch for vector #{i}"
+
+          # and it validates under the independent BIP341 script-path check
           script_bytes = Script.serialize_script(leaf.script)
 
           assert Taproot.validate_taproot_scriptpath_spend(q, script_bytes, control_block) ==
@@ -87,6 +105,12 @@ defmodule Bitcoinex.TaprootTest do
 
       tweak = Taproot.calculate_taptweak(p, <<>>)
       assert Bitcoinex.Utils.int_to_big(tweak, 32) == decode(e["intermediary"]["tweak"])
+    end
+  end
+
+  describe "create_p2tr/2 error paths" do
+    test "requires a non-nil internal key or script tree" do
+      assert {:error, _} = Script.create_p2tr(nil, nil)
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds the machinery to **construct and sign BIP341 key-path (Taproot) spends**, on top of the silent-payments stack. This is what lets the library spend **silent-payment outputs** (and BIP86 key-path outputs).

A silent-payment output places its output key directly in the scriptPubKey, so spending it is a key-path spend signed **directly** with the SP spending privkey `d` from `SilentPayments.spending_privkey/3` — **no** BIP341 taptweak. BIP86 / fresh-key spends instead tweak the internal key via `Taproot.tweak_privkey/2`. Both are supported.

## What's added

- **`lib/taproot.ex`** — new `Bitcoinex.Taproot`: key-path output tweak (`tweak_privkey/2`, `tweak_pubkey/2`, `calculate_taptweak/2`), TapLeaf/TapBranch tagged hashes, script-tree merkelization, and control-block construction/validation.
- **`lib/transaction.ex`** — BIP341 sighash: `bip341_sighash/7`, `bip341_sigmsg`, `bip341_tx_data`, the `bip341_sha_*` components, annex handling, and the BIP342 sigmsg extension; plus `In.serialize_prevout`/`serialize_prevouts`/`serialize_sequences` and `Witness.get_annex`.
- **`lib/script.ex`** — `serialize_with_compact_size/1` and **`create_p2tr/2`** (internal key P → output key Q). `create_p2tr/1` (treats arg as already-tweaked Q, used for SP outputs) is unchanged — **purely additive, no breaking change**.
- **`lib/utils.ex`** — `serialize_compact_size_unsigned_int/1`, `lexicographical_sort/2`.

## Testing — official vectors, non-circular

Driven by the official [BIP341 wallet test vectors](https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json) (vendored into `test/data/`):

- **All 7 `scriptPubKey` entries** (null / leaf / nested trees): merkle root, tweaked output key, and `create_p2tr/2` scriptPubKey, plus a control-block build↔validate round trip.
- **All 7 `keyPathSpending` inputs**, covering **every sighash flag** (DEFAULT/ALL/NONE/SINGLE + all three ANYONECANPAY variants): tweaked privkey, full sigMsg preimage, TapSighash, and the precomputed `sha_*` components — each compared to the BIP's ground-truth values.
- **Non-circular signature checks:** the signature we produce *and* the vector's own expected witness signature are both validated with an independent verifier (`Schnorr.verify_signature/3`) against the tweaked output key — never against our own signer.

Scope notes:
- **BIP340** sign/verify is already fully covered by the existing schnorr tests (official vectors 0–14; 15–18 use variable-length messages the 32-byte `z` API can't represent).
- **BIP342** script execution is out of scope for key-path spends.

`mix test` (294 tests, 0 failures) and `mix lint.all` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
