### PR TITLE
S1: Utils.pbkdf2/5 + Utils.int_list_to_bits/2

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -50,7 +50,8 @@ defmodule Bitcoinex.Utils do
 
   @doc """
   int_list_to_bits packs a list of non-negative integers into a bitstring,
-  MSB-first, using width bits per integer.
+  MSB-first, using width bits per integer. Each integer must fit in width
+  bits; larger values are truncated to their low width bits.
   """
   @spec int_list_to_bits(list(non_neg_integer()), pos_integer()) :: bitstring
   def int_list_to_bits(ints, width) do

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -38,6 +38,25 @@ defmodule Bitcoinex.Utils do
     )
   end
 
+  @doc """
+  pbkdf2 derives a key of key_len bytes from the password and salt using
+  PBKDF2-HMAC (RFC 2898). Callers own any string normalization and salt
+  construction (e.g. BIP-39 NFKD, SLIP-39 salt prefixes).
+  """
+  @spec pbkdf2(:sha256 | :sha512, binary, binary, pos_integer(), pos_integer()) :: binary
+  def pbkdf2(digest, password, salt, iterations, key_len) do
+    :crypto.pbkdf2_hmac(digest, password, salt, iterations, key_len)
+  end
+
+  @doc """
+  int_list_to_bits packs a list of non-negative integers into a bitstring,
+  MSB-first, using width bits per integer.
+  """
+  @spec int_list_to_bits(list(non_neg_integer()), pos_integer()) :: bitstring
+  def int_list_to_bits(ints, width) do
+    for i <- ints, into: <<>>, do: <<i::size(width)>>
+  end
+
   @typedoc """
     The pad_type describes the padding to use.
   """

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -51,11 +51,34 @@ defmodule Bitcoinex.Utils do
   @doc """
   int_list_to_bits packs a list of non-negative integers into a bitstring,
   MSB-first, using width bits per integer. Each integer must fit in width
-  bits; larger values are truncated to their low width bits.
+  bits; raises ArgumentError on any negative value or value >= 2^width so
+  that over-width inputs surface loudly rather than being silently truncated.
+
+  ## Examples
+
+      iex> Bitcoinex.Utils.int_list_to_bits([1, 2, 3], 11)
+      <<0, 32, 8, 1, 1::size(1)>>
+
+      iex> Bitcoinex.Utils.int_list_to_bits([1023, 0], 10)
+      <<255, 192, 0::size(4)>>
+
+      iex> Bitcoinex.Utils.int_list_to_bits([], 10)
+      <<>>
+
+      iex> Bitcoinex.Utils.int_list_to_bits([2048], 11)
+      ** (ArgumentError) integer 2048 does not fit in 11 bits
   """
   @spec int_list_to_bits(list(non_neg_integer()), pos_integer()) :: bitstring
   def int_list_to_bits(ints, width) do
-    for i <- ints, into: <<>>, do: <<i::size(width)>>
+    max = Bitwise.bsl(1, width)
+
+    for i <- ints, into: <<>> do
+      if i < 0 or i >= max do
+        raise ArgumentError, "integer #{i} does not fit in #{width} bits"
+      end
+
+      <<i::size(width)>>
+    end
   end
 
   @typedoc """

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Bitcoinex.MixProject do
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:mix_test_watch, "~> 1.1", only: :dev, runtime: false},
-      {:stream_data, "~> 0.1", only: :test},
+      {:stream_data, "~> 1.1", only: :test},
       {:decimal, "~> 1.0 or ~> 2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:benchee, ">= 1.0.0", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -26,6 +26,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
-  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
+  "stream_data": {:hex, :stream_data, "1.3.0", "bde37905530aff386dea1ddd86ecbf00e6642dc074ceffc10b7d4e41dfd6aac9", [:mix], [], "hexpm", "3cc552e286e817dca43c98044c706eec9318083a1480c52ae2688b08e2936e3c"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -57,6 +57,22 @@ defmodule Bitcoinex.UtilsTest do
       assert Utils.int_list_to_bits([], 10) == <<>>
     end
 
+    test "raises when a value does not fit in width bits" do
+      assert_raise ArgumentError, "integer 2048 does not fit in 11 bits", fn ->
+        Utils.int_list_to_bits([2048], 11)
+      end
+
+      assert_raise ArgumentError, "integer 1024 does not fit in 10 bits", fn ->
+        Utils.int_list_to_bits([0, 1024], 10)
+      end
+    end
+
+    test "raises on negative values" do
+      assert_raise ArgumentError, "integer -1 does not fit in 11 bits", fn ->
+        Utils.int_list_to_bits([-1], 11)
+      end
+    end
+
     property "round-trips against the bitstring comprehension" do
       check all(
               width <- StreamData.member_of([10, 11]),

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -49,6 +49,10 @@ defmodule Bitcoinex.UtilsTest do
       assert Utils.int_list_to_bits([1023, 0], 10) == <<1023::size(10), 0::size(10)>>
     end
 
+    test "packs the maximum 11-bit value" do
+      assert Utils.int_list_to_bits([2047], 11) == <<2047::size(11)>>
+    end
+
     test "empty list yields empty bitstring" do
       assert Utils.int_list_to_bits([], 10) == <<>>
     end
@@ -56,7 +60,7 @@ defmodule Bitcoinex.UtilsTest do
     property "round-trips against the bitstring comprehension" do
       check all(
               width <- StreamData.member_of([10, 11]),
-              ints <- StreamData.list_of(StreamData.integer(0..1023), max_length: 50)
+              ints <- StreamData.list_of(StreamData.integer(0..(2 ** width - 1)), max_length: 50)
             ) do
         bits = Utils.int_list_to_bits(ints, width)
         assert bit_size(bits) == length(ints) * width

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,0 +1,67 @@
+defmodule Bitcoinex.UtilsTest do
+  use ExUnit.Case
+  use ExUnitProperties
+  doctest Bitcoinex.Utils
+
+  alias Bitcoinex.Utils
+
+  describe "pbkdf2/5" do
+    # BIP-39 seed derivation: PBKDF2-HMAC-SHA512, 2048 iterations, 64 bytes.
+    # Vector from trezor/python-mnemonic vectors.json (english[0], passphrase "TREZOR").
+    test "derives the BIP-39 vector seed with sha512" do
+      mnemonic =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+      seed =
+        Base.decode16!(
+          "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+          case: :lower
+        )
+
+      assert Utils.pbkdf2(:sha512, mnemonic, "mnemonic" <> "TREZOR", 2048, 64) == seed
+    end
+
+    # RFC 7914 §11 PBKDF2-HMAC-SHA256 test vector.
+    test "derives the RFC 7914 vector with sha256" do
+      expected =
+        Base.decode16!(
+          "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783",
+          case: :lower
+        )
+
+      assert Utils.pbkdf2(:sha256, "passwd", "salt", 1, 64) == expected
+    end
+
+    test "key_len controls output size" do
+      assert byte_size(Utils.pbkdf2(:sha256, "pw", "salt", 1, 16)) == 16
+      assert byte_size(Utils.pbkdf2(:sha512, "pw", "salt", 1, 100)) == 100
+    end
+  end
+
+  describe "int_list_to_bits/2" do
+    test "packs 11-bit indices MSB-first" do
+      # 1 -> 00000000001, 2 -> 00000000010, 3 -> 00000000011
+      assert Utils.int_list_to_bits([1, 2, 3], 11) ==
+               <<1::size(11), 2::size(11), 3::size(11)>>
+    end
+
+    test "packs 10-bit indices" do
+      assert Utils.int_list_to_bits([1023, 0], 10) == <<1023::size(10), 0::size(10)>>
+    end
+
+    test "empty list yields empty bitstring" do
+      assert Utils.int_list_to_bits([], 10) == <<>>
+    end
+
+    property "round-trips against the bitstring comprehension" do
+      check all(
+              width <- StreamData.member_of([10, 11]),
+              ints <- StreamData.list_of(StreamData.integer(0..1023), max_length: 50)
+            ) do
+        bits = Utils.int_list_to_bits(ints, width)
+        assert bit_size(bits) == length(ints) * width
+        assert for(<<i::size(width) <- bits>>, do: i) == ints
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stack position: S0 → **S1** → S2 → S3 → S4 → S5 → S6 (spec §3.1, §3.10, §4)

- `Utils.pbkdf2/5` — thin wrapper over `:crypto.pbkdf2_hmac/5`; serves BIP-39 (SHA-512) and the SLIP-39 Feistel rounds (SHA-256). No normalization/salt logic inside — callers own that (spec §3.1 invariant).
- `Utils.int_list_to_bits/2` — MSB-first fixed-width packer shared by both word-encoding layers. Raises `ArgumentError` on any negative or `>= 2^width` value so over-width caller bugs surface loudly instead of being silently truncated to the low `width` bits.
- `test/utils_test.exs` (Utils was previously untested): BIP-39 english[0] TREZOR seed known-answer, RFC 7914 PBKDF2-HMAC-SHA256 known-answer, dkLen behavior, packing unit tests, overflow/negative guard tests, doctests, and a stream_data round-trip property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)