### PR TITLE
S3: GF(256) field + SLIP-39 Shamir split/recover

### DIFF
--- a/lib/slip39/cipher.ex
+++ b/lib/slip39/cipher.ex
@@ -1,0 +1,84 @@
+defmodule Bitcoinex.SLIP39.Cipher do
+  @moduledoc """
+  SLIP-39 master secret encryption.
+
+  Implements the four-round balanced Feistel cipher that SLIP-39 uses to
+  transform a master secret (MS) into an encrypted master secret (EMS) under a
+  passphrase, and back. The round function is PBKDF2-HMAC-SHA256 keyed by the
+  round index and passphrase, salted with the share identifier (unless the
+  share set is extendable, in which case the salt is empty).
+
+  Note that SLIP-39 passphrase decryption cannot fail: decrypting with a wrong
+  passphrase silently yields a different master secret.
+  """
+
+  import Bitwise
+
+  alias Bitcoinex.Utils
+
+  @base_iteration_count 10_000
+  @round_count 4
+  @customization_string_orig "shamir"
+
+  @doc """
+  Encrypts a master secret into an encrypted master secret.
+
+  `ms` must be of even length. The per-round PBKDF2 iteration count is
+  `2500 <<< iteration_exponent`. `identifier` is only used in the salt when
+  `extendable` is `false`.
+  """
+  @spec encrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
+  def encrypt(ms, passphrase, iteration_exponent, identifier, extendable) do
+    feistel(
+      ms,
+      Enum.to_list(0..(@round_count - 1)),
+      passphrase,
+      iteration_exponent,
+      identifier,
+      extendable
+    )
+  end
+
+  @doc """
+  Decrypts an encrypted master secret back into the master secret.
+
+  Inverse of `encrypt/5` for identical `(passphrase, iteration_exponent,
+  identifier, extendable)`; runs the Feistel rounds in reverse order.
+  """
+  @spec decrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
+  def decrypt(ems, passphrase, iteration_exponent, identifier, extendable) do
+    feistel(
+      ems,
+      Enum.to_list((@round_count - 1)..0//-1),
+      passphrase,
+      iteration_exponent,
+      identifier,
+      extendable
+    )
+  end
+
+  defp feistel(data, round_indices, passphrase, iteration_exponent, identifier, extendable) do
+    half = div(byte_size(data), 2)
+    <<l::binary-size(half), r::binary-size(half)>> = data
+
+    salt =
+      if extendable do
+        <<>>
+      else
+        @customization_string_orig <> <<identifier::16>>
+      end
+
+    iterations = div(@base_iteration_count <<< iteration_exponent, @round_count)
+
+    {l, r} =
+      Enum.reduce(round_indices, {l, r}, fn i, {l, r} ->
+        {r, Utils.xor_bytes(l, round_function(i, passphrase, salt, iterations, r))}
+      end)
+
+    r <> l
+  end
+
+  defp round_function(i, passphrase, salt, iterations, r) do
+    Utils.pbkdf2(:sha256, <<i>> <> passphrase, salt <> r, iterations, byte_size(r))
+  end
+end

--- a/lib/slip39/cipher.ex
+++ b/lib/slip39/cipher.ex
@@ -28,7 +28,8 @@ defmodule Bitcoinex.SLIP39.Cipher do
   `extendable` is `false`.
   """
   @spec encrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
-  def encrypt(ms, passphrase, iteration_exponent, identifier, extendable) do
+  def encrypt(ms, passphrase, iteration_exponent, identifier, extendable)
+      when rem(byte_size(ms), 2) == 0 and byte_size(ms) > 0 do
     feistel(
       ms,
       Enum.to_list(0..(@round_count - 1)),
@@ -46,7 +47,8 @@ defmodule Bitcoinex.SLIP39.Cipher do
   identifier, extendable)`; runs the Feistel rounds in reverse order.
   """
   @spec decrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
-  def decrypt(ems, passphrase, iteration_exponent, identifier, extendable) do
+  def decrypt(ems, passphrase, iteration_exponent, identifier, extendable)
+      when rem(byte_size(ems), 2) == 0 and byte_size(ems) > 0 do
     feistel(
       ems,
       Enum.to_list((@round_count - 1)..0//-1),

--- a/lib/slip39/cipher.ex
+++ b/lib/slip39/cipher.ex
@@ -10,6 +10,11 @@ defmodule Bitcoinex.SLIP39.Cipher do
 
   Note that SLIP-39 passphrase decryption cannot fail: decrypting with a wrong
   passphrase silently yields a different master secret.
+
+  `passphrase` is used as raw bytes; this module does not normalize it. The
+  SLIP-39 spec recommends restricting passphrases to printable ASCII
+  (codepoints 32-126) for cross-implementation interoperability, so the public
+  API built on top of this module should enforce that before calling in.
   """
 
   import Bitwise
@@ -26,10 +31,18 @@ defmodule Bitcoinex.SLIP39.Cipher do
   `ms` must be of even length. The per-round PBKDF2 iteration count is
   `2500 <<< iteration_exponent`. `identifier` is only used in the salt when
   `extendable` is `false`.
+
+  ## Examples
+
+      iex> ms = Base.decode16!("bb54aac4b89dc868ba37d9cc21b2cece", case: :lower)
+      iex> ems = Bitcoinex.SLIP39.Cipher.encrypt(ms, "TREZOR", 0, 7945, false)
+      iex> Bitcoinex.SLIP39.Cipher.decrypt(ems, "TREZOR", 0, 7945, false) == ms
+      true
   """
   @spec encrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
   def encrypt(ms, passphrase, iteration_exponent, identifier, extendable)
-      when rem(byte_size(ms), 2) == 0 and byte_size(ms) > 0 do
+      when rem(byte_size(ms), 2) == 0 and byte_size(ms) > 0 and
+             iteration_exponent in 0..15 and identifier in 0..0x7FFF do
     feistel(
       ms,
       Enum.to_list(0..(@round_count - 1)),
@@ -48,7 +61,8 @@ defmodule Bitcoinex.SLIP39.Cipher do
   """
   @spec decrypt(binary, binary, 0..15, 0..0x7FFF, boolean) :: binary
   def decrypt(ems, passphrase, iteration_exponent, identifier, extendable)
-      when rem(byte_size(ems), 2) == 0 and byte_size(ems) > 0 do
+      when rem(byte_size(ems), 2) == 0 and byte_size(ems) > 0 and
+             iteration_exponent in 0..15 and identifier in 0..0x7FFF do
     feistel(
       ems,
       Enum.to_list((@round_count - 1)..0//-1),

--- a/lib/slip39/gf256.ex
+++ b/lib/slip39/gf256.ex
@@ -1,0 +1,160 @@
+defmodule Bitcoinex.SLIP39.GF256 do
+  @moduledoc """
+  Arithmetic over the Galois field GF(256) used by SLIP-39 Shamir Secret Sharing.
+
+  The field is GF(2^8) with the Rijndael/AES reducing polynomial
+  `0x11B` (x^8 + x^4 + x^3 + x + 1). Field addition and subtraction are both
+  bitwise XOR. Multiplication and division are implemented with exp/log
+  tables generated at compile time from the generator `3` (0x03), which is a
+  primitive element of the field: the exp table has cycle length 255 and the
+  log table covers every nonzero element.
+
+  `interpolate/2` performs byte-lane-wise Lagrange interpolation over share
+  values, per the SLIP-39 formula
+  `f(x) = sum_i y_i * prod_{j != i} (x - x_j) / (x_i - x_j)`.
+  """
+
+  import Bitwise
+
+  # Compile-time exp/log table generation. NOTE: a same-module defp is not
+  # callable at this module's own compile time, so the shift-and-reduce
+  # ("Russian peasant") multiplication is an anonymous function evaluated in
+  # the module body.
+  slow_mul = fn a, b ->
+    0..7
+    |> Enum.reduce({0, a}, fn i, {acc, shifted} ->
+      acc = if (b >>> i &&& 1) == 1, do: bxor(acc, shifted), else: acc
+      shifted = shifted <<< 1
+      shifted = if shifted > 0xFF, do: bxor(shifted, 0x11B), else: shifted
+      {acc, shifted}
+    end)
+    |> elem(0)
+  end
+
+  # exp_list = [3^0, 3^1, ..., 3^254]; 3^255 wraps back to 1 (cycle length 255).
+  {exp_list, wrap} = Enum.map_reduce(0..254, 1, fn _i, x -> {x, slow_mul.(x, 3)} end)
+
+  # Compile-time sanity checks: the cycle closes at 1 and the 255 powers of 3
+  # are distinct, i.e. 3 generates the whole multiplicative group.
+  1 = wrap
+  log_by_value = exp_list |> Enum.with_index() |> Map.new()
+  255 = map_size(log_by_value)
+
+  @exp_table List.to_tuple(exp_list)
+  # log[0] is undefined in the field; slot 0 holds a placeholder that is
+  # never read (mul/divide/pow short-circuit on 0 before any table lookup).
+  @log_table 0..255 |> Enum.map(&Map.get(log_by_value, &1, 0)) |> List.to_tuple()
+
+  @doc """
+  Field addition (== subtraction): bitwise XOR.
+
+  ## Examples
+
+      iex> Bitcoinex.SLIP39.GF256.add(0x57, 0x13)
+      0x44
+
+      iex> Bitcoinex.SLIP39.GF256.add(0xAB, 0xAB)
+      0
+  """
+  @spec add(byte(), byte()) :: byte()
+  def add(a, b), do: bxor(a, b)
+
+  @doc """
+  Field multiplication via the exp/log tables.
+
+  ## Examples
+
+  The FIPS-197 (AES) known answer `{57} * {13} = {fe}`:
+
+      iex> Bitcoinex.SLIP39.GF256.mul(0x57, 0x13)
+      0xFE
+  """
+  @spec mul(byte(), byte()) :: byte()
+  def mul(0, _b), do: 0
+  def mul(_a, 0), do: 0
+
+  def mul(a, b) do
+    elem(@exp_table, rem(elem(@log_table, a) + elem(@log_table, b), 255))
+  end
+
+  @doc """
+  Field division: `a / b`. Raises `ArithmeticError` when `b == 0`.
+
+  Named `divide/2` rather than `div/2`: a local `div/2` conflicts with the
+  auto-imported `Kernel.div/2`.
+
+  ## Examples
+
+      iex> Bitcoinex.SLIP39.GF256.divide(0xFE, 0x13)
+      0x57
+  """
+  @spec divide(byte(), byte()) :: byte()
+  def divide(_a, 0), do: raise(ArithmeticError)
+  def divide(0, _b), do: 0
+
+  def divide(a, b) do
+    elem(@exp_table, Integer.mod(elem(@log_table, a) - elem(@log_table, b), 255))
+  end
+
+  @doc """
+  Field exponentiation: `a` raised to the (integer) power `n`.
+
+  `pow(a, 0) == 1` for all `a` (including 0, by convention). Negative
+  exponents are supported for nonzero `a` (multiplicative inverse); a
+  negative power of 0 raises `ArithmeticError`.
+
+  ## Examples
+
+      iex> Bitcoinex.SLIP39.GF256.pow(3, 255)
+      1
+  """
+  @spec pow(byte(), integer()) :: byte()
+  def pow(_a, 0), do: 1
+  def pow(0, n) when n > 0, do: 0
+  def pow(0, _n), do: raise(ArithmeticError)
+
+  def pow(a, n) do
+    elem(@exp_table, Integer.mod(elem(@log_table, a) * n, 255))
+  end
+
+  @doc """
+  Lagrange interpolation of the polynomial defined by `points`, evaluated at
+  `x`, independently for each byte lane of the share values.
+
+  `points` is a list of `{x_i, y_i}` where each `y_i` is a binary of the same
+  length `n`; the return value is the `n`-byte binary `f(x)`. All `x_i` must
+  be distinct (caller-guaranteed). If `x` equals one of the `x_i`, the
+  corresponding `y_i` is returned directly.
+
+  ## Examples
+
+      iex> Bitcoinex.SLIP39.GF256.interpolate([{0, <<9, 9>>}, {1, <<9, 9>>}], 255)
+      <<9, 9>>
+  """
+  @spec interpolate([{byte(), binary()}], byte()) :: binary()
+  def interpolate(points, x) do
+    case List.keyfind(points, x, 0) do
+      {^x, y} -> y
+      nil -> lagrange_interpolate(points, x)
+    end
+  end
+
+  defp lagrange_interpolate([{_x0, y0} | _] = points, x) do
+    xs = Enum.map(points, fn {xi, _yi} -> xi end)
+    zero_lanes = List.duplicate(0, byte_size(y0))
+
+    points
+    |> Enum.map(fn {xi, yi} ->
+      coefficient =
+        xs
+        |> Enum.reject(&(&1 == xi))
+        |> Enum.reduce(1, fn xj, acc ->
+          mul(acc, divide(add(x, xj), add(xi, xj)))
+        end)
+
+      yi |> :binary.bin_to_list() |> Enum.map(&mul(coefficient, &1))
+    end)
+    |> Enum.reduce(zero_lanes, fn lanes, acc -> Enum.zip_with(lanes, acc, &bxor/2) end)
+    |> :binary.list_to_bin()
+  end
+end

--- a/lib/slip39/gf256.ex
+++ b/lib/slip39/gf256.ex
@@ -74,7 +74,10 @@ defmodule Bitcoinex.SLIP39.GF256 do
   def mul(_a, 0), do: 0
 
   def mul(a, b) do
-    elem(@exp_table, rem(elem(@log_table, a) + elem(@log_table, b), 255))
+    # Integer.mod (not rem) to stay consistent with divide/2 and pow/2, whose
+    # operands can go negative; the sum here is always non-negative, so the two
+    # would agree, but a uniform reduction avoids a future copy-paste footgun.
+    elem(@exp_table, Integer.mod(elem(@log_table, a) + elem(@log_table, b), 255))
   end
 
   @doc """

--- a/lib/slip39/gf256.ex
+++ b/lib/slip39/gf256.ex
@@ -89,7 +89,7 @@ defmodule Bitcoinex.SLIP39.GF256 do
       0x57
   """
   @spec divide(byte(), byte()) :: byte()
-  def divide(_a, 0), do: raise(ArithmeticError)
+  def divide(_a, 0), do: raise(ArithmeticError, message: "GF(256) division by zero")
   def divide(0, _b), do: 0
 
   def divide(a, b) do
@@ -111,7 +111,7 @@ defmodule Bitcoinex.SLIP39.GF256 do
   @spec pow(byte(), integer()) :: byte()
   def pow(_a, 0), do: 1
   def pow(0, n) when n > 0, do: 0
-  def pow(0, _n), do: raise(ArithmeticError)
+  def pow(0, _n), do: raise(ArithmeticError, message: "GF(256) 0 raised to a negative power")
 
   def pow(a, n) do
     elem(@exp_table, Integer.mod(elem(@log_table, a) * n, 255))
@@ -124,7 +124,8 @@ defmodule Bitcoinex.SLIP39.GF256 do
   `points` is a list of `{x_i, y_i}` where each `y_i` is a binary of the same
   length `n`; the return value is the `n`-byte binary `f(x)`. All `x_i` must
   be distinct (caller-guaranteed). If `x` equals one of the `x_i`, the
-  corresponding `y_i` is returned directly.
+  corresponding `y_i` is returned directly. Raises `ArgumentError` if the
+  `y_i` do not all share the same byte length.
 
   ## Examples
 
@@ -140,8 +141,14 @@ defmodule Bitcoinex.SLIP39.GF256 do
   end
 
   defp lagrange_interpolate([{_x0, y0} | _] = points, x) do
+    lane_count = byte_size(y0)
+
+    unless Enum.all?(points, fn {_xi, yi} -> byte_size(yi) == lane_count end) do
+      raise ArgumentError, "interpolation points must all have the same byte length"
+    end
+
     xs = Enum.map(points, fn {xi, _yi} -> xi end)
-    zero_lanes = List.duplicate(0, byte_size(y0))
+    zero_lanes = List.duplicate(0, lane_count)
 
     points
     |> Enum.map(fn {xi, yi} ->

--- a/lib/slip39/shamir.ex
+++ b/lib/slip39/shamir.ex
@@ -88,15 +88,27 @@ defmodule Bitcoinex.SLIP39.Shamir do
 
   When `threshold == 1` the single share's value is the secret. Otherwise the
   secret (index 255) and digest share (index 254) are interpolated from the
-  given points and the digest is verified. Rejections, checked in order:
+  given points and the digest is verified. *Every* passed share is used in the
+  interpolation, so the caller decides which shares to hand in: supplying more
+  than `threshold` shares works only if all of them lie on the polynomial — one
+  corrupt extra share fails the whole recovery with `{:error, :invalid_digest}`
+  rather than falling back to a valid `threshold`-sized subset. Rejections,
+  checked in order:
 
   - fewer than `threshold` shares yields `{:error, :insufficient_shares}`;
+  - an index outside the valid share range `0..#{@max_share_count - 1}` (which
+    includes the reserved digest/secret anchor indices 254/255) yields
+    `{:error, :invalid_share_index}`;
   - duplicate share indices yield `{:error, :duplicate_share_indices}`;
   - a wrong or corrupted share set yields `{:error, :invalid_digest}`.
   """
   @spec recover_secret(1..16, [{byte(), binary()}]) ::
           {:ok, binary()}
-          | {:error, :invalid_digest | :duplicate_share_indices | :insufficient_shares}
+          | {:error,
+             :invalid_digest
+             | :duplicate_share_indices
+             | :insufficient_shares
+             | :invalid_share_index}
   def recover_secret(1, [{_index, value} | _rest]), do: {:ok, value}
   def recover_secret(1, []), do: {:error, :insufficient_shares}
 
@@ -106,6 +118,14 @@ defmodule Bitcoinex.SLIP39.Shamir do
     cond do
       length(shares) < threshold ->
         {:error, :insufficient_shares}
+
+      # Real share indices are always 0..count-1 with count <= @max_share_count.
+      # Rejecting anything outside that range keeps a caller-supplied index from
+      # colliding with the reserved anchors (254/255): such an index would make
+      # GF256.interpolate short-circuit on its keyfind fast path and hand back a
+      # share's raw value in place of a genuinely interpolated secret/digest.
+      Enum.any?(indices, &(&1 not in 0..(@max_share_count - 1))) ->
+        {:error, :invalid_share_index}
 
       indices != Enum.uniq(indices) ->
         {:error, :duplicate_share_indices}

--- a/lib/slip39/shamir.ex
+++ b/lib/slip39/shamir.ex
@@ -11,8 +11,10 @@ defmodule Bitcoinex.SLIP39.Shamir do
     `x = 255` and a digest share at `x = 254`. The digest share is
     `HMAC-SHA256(random_part, secret)` truncated to its first 4 bytes,
     concatenated with the `n - 4`-byte `random_part`. On recovery the digest
-    is recomputed and verified, rejecting wrong or insufficient share sets
-    with `{:error, :invalid_digest}` (false-accept probability ~2^-32).
+    is recomputed and verified, rejecting wrong share sets with
+    `{:error, :invalid_digest}` (false-accept probability ~2^-32). Share sets
+    with fewer than `threshold` shares are rejected deterministically up front
+    with `{:error, :insufficient_shares}`.
   - `threshold == 1` is a special case: every share is the secret verbatim.
 
   Randomness is injected via an `rng` function (`byte_count -> binary`).
@@ -36,6 +38,10 @@ defmodule Bitcoinex.SLIP39.Shamir do
   secret anchor points are placed at indices 254 and 255, and the remaining
   share indices are interpolated from those `threshold` points.
 
+  For `threshold >= 2` the secret must be at least
+  #{@digest_length_bytes} bytes long (so the digest share's random part is
+  non-negative); a shorter secret raises `FunctionClauseError`.
+
   ## Examples
 
       iex> rng = fn byte_count -> :binary.copy(<<7>>, byte_count) end
@@ -54,7 +60,8 @@ defmodule Bitcoinex.SLIP39.Shamir do
   # and secret (255) anchor indices; an uncapped count would emit the secret
   # verbatim as the share at index 255
   def split_secret(threshold, count, secret, rng)
-      when threshold >= 2 and threshold <= count and count <= @max_share_count do
+      when threshold >= 2 and threshold <= count and count <= @max_share_count and
+             byte_size(secret) >= @digest_length_bytes do
     random_share_count = threshold - 2
 
     base_shares =
@@ -81,29 +88,37 @@ defmodule Bitcoinex.SLIP39.Shamir do
 
   When `threshold == 1` the single share's value is the secret. Otherwise the
   secret (index 255) and digest share (index 254) are interpolated from the
-  given points and the digest is verified; a wrong, corrupted, or
-  under-threshold share set yields `{:error, :invalid_digest}`. Share
-  indices must be distinct; duplicates yield
-  `{:error, :duplicate_share_indices}`.
+  given points and the digest is verified. Rejections, checked in order:
+
+  - fewer than `threshold` shares yields `{:error, :insufficient_shares}`;
+  - duplicate share indices yield `{:error, :duplicate_share_indices}`;
+  - a wrong or corrupted share set yields `{:error, :invalid_digest}`.
   """
   @spec recover_secret(1..16, [{byte(), binary()}]) ::
-          {:ok, binary()} | {:error, :invalid_digest | :duplicate_share_indices}
+          {:ok, binary()}
+          | {:error, :invalid_digest | :duplicate_share_indices | :insufficient_shares}
   def recover_secret(1, [{_index, value} | _rest]), do: {:ok, value}
+  def recover_secret(1, []), do: {:error, :insufficient_shares}
 
   def recover_secret(threshold, shares) when threshold >= 2 do
     indices = Enum.map(shares, fn {index, _value} -> index end)
 
-    if indices == Enum.uniq(indices) do
-      secret = GF256.interpolate(shares, @secret_index)
-      digest_share = GF256.interpolate(shares, @digest_index)
+    cond do
+      length(shares) < threshold ->
+        {:error, :insufficient_shares}
 
-      if valid_digest?(digest_share, secret) do
-        {:ok, secret}
-      else
-        {:error, :invalid_digest}
-      end
-    else
-      {:error, :duplicate_share_indices}
+      indices != Enum.uniq(indices) ->
+        {:error, :duplicate_share_indices}
+
+      true ->
+        secret = GF256.interpolate(shares, @secret_index)
+        digest_share = GF256.interpolate(shares, @digest_index)
+
+        if valid_digest?(digest_share, secret) do
+          {:ok, secret}
+        else
+          {:error, :invalid_digest}
+        end
     end
   end
 

--- a/lib/slip39/shamir.ex
+++ b/lib/slip39/shamir.ex
@@ -1,0 +1,127 @@
+defmodule Bitcoinex.SLIP39.Shamir do
+  @moduledoc """
+  SLIP-39 Shamir Secret Sharing over GF(256).
+
+  A secret of `n` bytes is split into `count` shares such that any
+  `threshold` of them reconstruct it, per SLIP-0039:
+
+  - Each share is a point `{x, y}` where `x` is the share index and `y` is an
+    `n`-byte binary; interpolation runs independently per byte lane.
+  - The shared polynomial is anchored at two reserved indices: the secret at
+    `x = 255` and a digest share at `x = 254`. The digest share is
+    `HMAC-SHA256(random_part, secret)` truncated to its first 4 bytes,
+    concatenated with the `n - 4`-byte `random_part`. On recovery the digest
+    is recomputed and verified, rejecting wrong or insufficient share sets
+    with `{:error, :invalid_digest}` (false-accept probability ~2^-32).
+  - `threshold == 1` is a special case: every share is the secret verbatim.
+
+  Randomness is injected via an `rng` function (`byte_count -> binary`).
+  Production callers MUST pass a CSPRNG such as `&:crypto.strong_rand_bytes/1`;
+  a deterministic rng is intended only for tests.
+  """
+
+  alias Bitcoinex.SLIP39.GF256
+
+  @digest_length_bytes 4
+  @digest_index 254
+  @secret_index 255
+
+  @doc """
+  Splits `secret` into `count` shares recoverable from any `threshold` of them.
+
+  Returns a list of `{index, share_value}` points with indices `0..count-1`.
+  When `threshold == 1`, every share equals `secret`. Otherwise
+  `threshold - 2` random base shares are drawn from `rng`, the digest and
+  secret anchor points are placed at indices 254 and 255, and the remaining
+  share indices are interpolated from those `threshold` points.
+
+  ## Examples
+
+      iex> rng = fn byte_count -> :binary.copy(<<7>>, byte_count) end
+      iex> secret = :binary.copy(<<42>>, 16)
+      iex> shares = Bitcoinex.SLIP39.Shamir.split_secret(2, 3, secret, rng)
+      iex> {:ok, recovered} = Bitcoinex.SLIP39.Shamir.recover_secret(2, Enum.take(shares, 2))
+      iex> recovered == secret
+      true
+  """
+  @spec split_secret(1..16, 1..16, binary(), (pos_integer() -> binary())) :: [{byte(), binary()}]
+  def split_secret(1, count, secret, _rng) do
+    for i <- 0..(count - 1), do: {i, secret}
+  end
+
+  def split_secret(threshold, count, secret, rng)
+      when threshold >= 2 and threshold <= count do
+    random_share_count = threshold - 2
+
+    base_shares =
+      for i <- 0..(random_share_count - 1)//1 do
+        {i, rng.(byte_size(secret))}
+      end
+
+    random_part = rng.(byte_size(secret) - @digest_length_bytes)
+    digest = create_digest(random_part, secret)
+
+    anchor_points =
+      base_shares ++ [{@digest_index, digest}, {@secret_index, secret}]
+
+    interpolated_shares =
+      for i <- random_share_count..(count - 1)//1 do
+        {i, GF256.interpolate(anchor_points, i)}
+      end
+
+    base_shares ++ interpolated_shares
+  end
+
+  @doc """
+  Recovers the secret from `shares` (a list of `{index, share_value}` points).
+
+  When `threshold == 1` the single share's value is the secret. Otherwise the
+  secret (index 255) and digest share (index 254) are interpolated from the
+  given points and the digest is verified; a wrong, corrupted, or
+  under-threshold share set yields `{:error, :invalid_digest}`.
+  """
+  @spec recover_secret(1..16, [{byte(), binary()}]) ::
+          {:ok, binary()} | {:error, :invalid_digest}
+  def recover_secret(1, [{_index, value} | _rest]), do: {:ok, value}
+
+  def recover_secret(threshold, shares) when threshold >= 2 do
+    secret = GF256.interpolate(shares, @secret_index)
+    digest_share = GF256.interpolate(shares, @digest_index)
+
+    if valid_digest?(digest_share, secret) do
+      {:ok, secret}
+    else
+      {:error, :invalid_digest}
+    end
+  end
+
+  @doc """
+  Builds the digest share for `shared_secret`: the first
+  #{@digest_length_bytes} bytes of `HMAC-SHA256(random, shared_secret)`
+  concatenated with `random`.
+
+  ## Examples
+
+      iex> digest = Bitcoinex.SLIP39.Shamir.create_digest(<<1, 2, 3>>, <<4, 5, 6, 7>>)
+      iex> Bitcoinex.SLIP39.Shamir.valid_digest?(digest, <<4, 5, 6, 7>>)
+      true
+  """
+  @spec create_digest(binary(), binary()) :: binary()
+  def create_digest(random, shared_secret) do
+    <<digest::binary-size(@digest_length_bytes), _rest::binary>> =
+      :crypto.mac(:hmac, :sha256, random, shared_secret)
+
+    digest <> random
+  end
+
+  @doc """
+  Verifies that `digest_share` is the digest share of `shared_secret`, i.e.
+  that its leading #{@digest_length_bytes} bytes match the HMAC-SHA256 of
+  `shared_secret` keyed with the trailing random part.
+  """
+  @spec valid_digest?(binary(), binary()) :: boolean()
+  def valid_digest?(digest_share, shared_secret) do
+    <<_digest::binary-size(@digest_length_bytes), random::binary>> = digest_share
+    create_digest(random, shared_secret) == digest_share
+  end
+end

--- a/lib/slip39/shamir.ex
+++ b/lib/slip39/shamir.ex
@@ -25,6 +25,7 @@ defmodule Bitcoinex.SLIP39.Shamir do
   @digest_length_bytes 4
   @digest_index 254
   @secret_index 255
+  @max_share_count 16
 
   @doc """
   Splits `secret` into `count` shares recoverable from any `threshold` of them.
@@ -45,12 +46,15 @@ defmodule Bitcoinex.SLIP39.Shamir do
       true
   """
   @spec split_secret(1..16, 1..16, binary(), (pos_integer() -> binary())) :: [{byte(), binary()}]
-  def split_secret(1, count, secret, _rng) do
+  def split_secret(1, count, secret, _rng) when count in 1..@max_share_count do
     for i <- 0..(count - 1), do: {i, secret}
   end
 
+  # count is capped so share indices can never collide with the digest (254)
+  # and secret (255) anchor indices; an uncapped count would emit the secret
+  # verbatim as the share at index 255
   def split_secret(threshold, count, secret, rng)
-      when threshold >= 2 and threshold <= count do
+      when threshold >= 2 and threshold <= count and count <= @max_share_count do
     random_share_count = threshold - 2
 
     base_shares =
@@ -78,20 +82,28 @@ defmodule Bitcoinex.SLIP39.Shamir do
   When `threshold == 1` the single share's value is the secret. Otherwise the
   secret (index 255) and digest share (index 254) are interpolated from the
   given points and the digest is verified; a wrong, corrupted, or
-  under-threshold share set yields `{:error, :invalid_digest}`.
+  under-threshold share set yields `{:error, :invalid_digest}`. Share
+  indices must be distinct; duplicates yield
+  `{:error, :duplicate_share_indices}`.
   """
   @spec recover_secret(1..16, [{byte(), binary()}]) ::
-          {:ok, binary()} | {:error, :invalid_digest}
+          {:ok, binary()} | {:error, :invalid_digest | :duplicate_share_indices}
   def recover_secret(1, [{_index, value} | _rest]), do: {:ok, value}
 
   def recover_secret(threshold, shares) when threshold >= 2 do
-    secret = GF256.interpolate(shares, @secret_index)
-    digest_share = GF256.interpolate(shares, @digest_index)
+    indices = Enum.map(shares, fn {index, _value} -> index end)
 
-    if valid_digest?(digest_share, secret) do
-      {:ok, secret}
+    if indices == Enum.uniq(indices) do
+      secret = GF256.interpolate(shares, @secret_index)
+      digest_share = GF256.interpolate(shares, @digest_index)
+
+      if valid_digest?(digest_share, secret) do
+        {:ok, secret}
+      else
+        {:error, :invalid_digest}
+      end
     else
-      {:error, :invalid_digest}
+      {:error, :duplicate_share_indices}
     end
   end
 

--- a/test/slip39/cipher_test.exs
+++ b/test/slip39/cipher_test.exs
@@ -96,6 +96,10 @@ defmodule Bitcoinex.SLIP39.CipherTest do
     end
   end
 
+  # TODO(S5): replace this hand-rolled extraction with the real Share codec
+  # once it lands, so the known-answer test exercises production parsing rather
+  # than a test-local reimplementation of the wire layout.
+  #
   # Hand-extracts (identifier, extendable, iteration_exponent, ems) from a
   # 20-word 1-of-1 SLIP-39 share mnemonic, following the wire layout in the
   # SLIP-39 spec (each word is a 10-bit index into priv/slip39_english.txt):

--- a/test/slip39/cipher_test.exs
+++ b/test/slip39/cipher_test.exs
@@ -69,10 +69,38 @@ defmodule Bitcoinex.SLIP39.CipherTest do
 
       ms = Base.decode16!("bb54aac4b89dc868ba37d9cc21b2cece", case: :lower)
 
-      {identifier, extendable, iteration_exponent, ems} = extract_share_params(mnemonic)
+      {identifier, extendable, iteration_exponent, ems} =
+        extract_share_params(mnemonic, byte_size(ms))
 
       # Lock down the extraction itself so a helper bug cannot mask a cipher bug.
       assert identifier == 7945
+      assert extendable == false
+      assert iteration_exponent == 0
+
+      assert Cipher.decrypt(ems, "TREZOR", iteration_exponent, identifier, extendable) == ms
+      # encryption is the exact inverse
+      assert Cipher.encrypt(ms, "TREZOR", iteration_exponent, identifier, extendable) == ems
+    end
+
+    # Official vector index 19 from test/data/slip39_vectors.json:
+    # "20. Valid mnemonic without sharing (256 bits)", passphrase "TREZOR".
+    # A 33-word share exercises a longer EMS and a different pad width (4 bits)
+    # than the 128-bit vector, catching half-splitting or length bugs that a
+    # same-length round-trip cannot.
+    test "known-answer: decrypts the EMS embedded in official vector 20 (256 bits)" do
+      mnemonic =
+        "theory painting academic academic armed sweater year military elder discuss " <>
+          "acne wildlife boring employer fused large satoshi bundle carbon diagnose " <>
+          "anatomy hamster leaves tracks paces beyond phantom capital marvel lips " <>
+          "brave detect luck"
+
+      ms = @ms32
+
+      {identifier, extendable, iteration_exponent, ems} =
+        extract_share_params(mnemonic, byte_size(ms))
+
+      # Lock down the extraction itself so a helper bug cannot mask a cipher bug.
+      assert identifier == 29_172
       assert extendable == false
       assert iteration_exponent == 0
 
@@ -101,21 +129,24 @@ defmodule Bitcoinex.SLIP39.CipherTest do
   # than a test-local reimplementation of the wire layout.
   #
   # Hand-extracts (identifier, extendable, iteration_exponent, ems) from a
-  # 20-word 1-of-1 SLIP-39 share mnemonic, following the wire layout in the
-  # SLIP-39 spec (each word is a 10-bit index into priv/slip39_english.txt):
+  # 1-of-1 SLIP-39 share mnemonic, following the wire layout in the SLIP-39
+  # spec (each word is a 10-bit index into priv/slip39_english.txt):
   #
-  #   20 words * 10 bits = 200 bits; the last 3 words (30 bits) are the
-  #   RS1024 checksum, leaving 170 data bits:
+  #   N words * 10 bits total; the last 3 words (30 bits) are the RS1024
+  #   checksum, leaving (N - 3) * 10 data bits:
   #
   #   <<identifier::15, ext::1, iteration_exponent::4,
   #     group_index::4, group_threshold-1::4, group_count-1::4,
-  #     member_index::4, member_threshold-1::4,        # 40 metadata bits
-  #     padding::2, share_value::binary-size(16)>>     # 130 value bits
+  #     member_index::4, member_threshold-1::4,          # 40 metadata bits
+  #     padding::pad_bits, share_value::binary-size(n)>>  # padded share value
   #
-  #   The 130 value bits carry pad_bits = rem(130, 16) = 2 leading zero bits,
-  #   so the share value is the trailing 128 bits (16 bytes). For a 1-of-1
-  #   share the share value IS the encrypted master secret (EMS).
-  defp extract_share_params(mnemonic) do
+  #   The share value is left-padded with zero bits to word-align the mnemonic.
+  #   For a 1-of-1 share the share value IS the encrypted master secret (EMS),
+  #   whose byte length equals the master secret's, so the caller passes
+  #   `ems_bytes` and the padding width is whatever remains. (The pad width is
+  #   not always < 8 — a 24-byte secret pads with 8 bits — so it cannot be
+  #   inferred from the value length alone; the caller-supplied size is exact.)
+  defp extract_share_params(mnemonic, ems_bytes) do
     indices =
       mnemonic
       |> String.split()
@@ -123,9 +154,12 @@ defmodule Bitcoinex.SLIP39.CipherTest do
       |> Enum.drop(-3)
       |> Enum.map(&Map.fetch!(word_index(), &1))
 
+    bits = Utils.int_list_to_bits(indices, 10)
+    pad_bits = bit_size(bits) - 40 - ems_bytes * 8
+
     <<identifier::15, ext_bit::1, iteration_exponent::4, _group_index::4, _group_threshold_m1::4,
-      _group_count_m1::4, _member_index::4, _member_threshold_m1::4, 0::2,
-      ems::binary-size(16)>> = Utils.int_list_to_bits(indices, 10)
+      _group_count_m1::4, _member_index::4, _member_threshold_m1::4, 0::size(pad_bits),
+      ems::binary-size(ems_bytes)>> = bits
 
     {identifier, ext_bit == 1, iteration_exponent, ems}
   end

--- a/test/slip39/cipher_test.exs
+++ b/test/slip39/cipher_test.exs
@@ -1,0 +1,129 @@
+defmodule Bitcoinex.SLIP39.CipherTest do
+  use ExUnit.Case
+  use ExUnitProperties
+  doctest Bitcoinex.SLIP39.Cipher
+
+  alias Bitcoinex.SLIP39.Cipher
+  alias Bitcoinex.Utils
+
+  @ms16 Base.decode16!("0ff784df000c4380a5ed683f7e6e3dcf", case: :lower)
+  @ms32 Base.decode16!(
+          "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92",
+          case: :lower
+        )
+
+  describe "encrypt/5 and decrypt/5" do
+    test "round-trip identity across ext, e, passphrase, and MS length" do
+      for ms <- [@ms16, @ms32],
+          passphrase <- ["", "TREZOR"],
+          e <- [0, 1],
+          ext <- [true, false] do
+        ems = Cipher.encrypt(ms, passphrase, e, 3141, ext)
+        assert byte_size(ems) == byte_size(ms)
+        assert ems != ms
+        assert Cipher.decrypt(ems, passphrase, e, 3141, ext) == ms
+      end
+    end
+
+    test "extendable flag selects the salt" do
+      ems_ext = Cipher.encrypt(@ms16, "pw", 0, 123, true)
+      ems_orig = Cipher.encrypt(@ms16, "pw", 0, 123, false)
+
+      # ext == true (empty salt) vs ext == false ("shamir" <> id) must differ
+      # for otherwise-identical inputs.
+      assert ems_ext != ems_orig
+
+      # Extendable shares use an empty salt, so the identifier is ignored.
+      assert Cipher.encrypt(@ms16, "pw", 0, 456, true) == ems_ext
+
+      # Non-extendable shares salt with "shamir" <> <<id::16>>, so the
+      # identifier changes the ciphertext.
+      refute Cipher.encrypt(@ms16, "pw", 0, 456, false) == ems_orig
+    end
+
+    test "iteration exponent is threaded into the round function" do
+      ems_e0 = Cipher.encrypt(@ms16, "pw", 0, 123, true)
+      ems_e1 = Cipher.encrypt(@ms16, "pw", 1, 123, true)
+
+      assert ems_e0 != ems_e1
+      # decrypting with the wrong exponent yields a different (wrong) MS
+      refute Cipher.decrypt(ems_e0, "pw", 1, 123, true) == @ms16
+    end
+
+    # Official vector index 0 from test/data/slip39_vectors.json:
+    # "1. Valid mnemonic without sharing (128 bits)", passphrase "TREZOR".
+    # The Share codec does not exist yet (PR S5), so the EMS and cipher
+    # parameters are hand-extracted from the mnemonic's wire layout by
+    # extract_share_params/1 below.
+    test "known-answer: decrypts the EMS embedded in official vector 1" do
+      mnemonic =
+        "duckling enlarge academic academic agency result length solution fridge " <>
+          "kidney coal piece deal husband erode duke ajar critical decision keyboard"
+
+      ms = Base.decode16!("bb54aac4b89dc868ba37d9cc21b2cece", case: :lower)
+
+      {identifier, extendable, iteration_exponent, ems} = extract_share_params(mnemonic)
+
+      # Lock down the extraction itself so a helper bug cannot mask a cipher bug.
+      assert identifier == 7945
+      assert extendable == false
+      assert iteration_exponent == 0
+
+      assert Cipher.decrypt(ems, "TREZOR", iteration_exponent, identifier, extendable) == ms
+      # encryption is the exact inverse
+      assert Cipher.encrypt(ms, "TREZOR", iteration_exponent, identifier, extendable) == ems
+    end
+  end
+
+  property "decrypt(encrypt(ms, ...), ...) == ms" do
+    check all(
+            half_len <- integer(8..16),
+            ms <- binary(length: half_len * 2),
+            passphrase <- string(:ascii, max_length: 16),
+            e <- integer(0..2),
+            ext <- boolean(),
+            identifier <- integer(0..0x7FFF)
+          ) do
+      ems = Cipher.encrypt(ms, passphrase, e, identifier, ext)
+      assert Cipher.decrypt(ems, passphrase, e, identifier, ext) == ms
+    end
+  end
+
+  # Hand-extracts (identifier, extendable, iteration_exponent, ems) from a
+  # 20-word 1-of-1 SLIP-39 share mnemonic, following the wire layout in the
+  # SLIP-39 spec (each word is a 10-bit index into priv/slip39_english.txt):
+  #
+  #   20 words * 10 bits = 200 bits; the last 3 words (30 bits) are the
+  #   RS1024 checksum, leaving 170 data bits:
+  #
+  #   <<identifier::15, ext::1, iteration_exponent::4,
+  #     group_index::4, group_threshold-1::4, group_count-1::4,
+  #     member_index::4, member_threshold-1::4,        # 40 metadata bits
+  #     padding::2, share_value::binary-size(16)>>     # 130 value bits
+  #
+  #   The 130 value bits carry pad_bits = rem(130, 16) = 2 leading zero bits,
+  #   so the share value is the trailing 128 bits (16 bytes). For a 1-of-1
+  #   share the share value IS the encrypted master secret (EMS).
+  defp extract_share_params(mnemonic) do
+    indices =
+      mnemonic
+      |> String.split()
+      # strip the 3 RS1024 checksum words
+      |> Enum.drop(-3)
+      |> Enum.map(&Map.fetch!(word_index(), &1))
+
+    <<identifier::15, ext_bit::1, iteration_exponent::4, _group_index::4, _group_threshold_m1::4,
+      _group_count_m1::4, _member_index::4, _member_threshold_m1::4, 0::2,
+      ems::binary-size(16)>> = Utils.int_list_to_bits(indices, 10)
+
+    {identifier, ext_bit == 1, iteration_exponent, ems}
+  end
+
+  defp word_index do
+    "priv/slip39_english.txt"
+    |> File.read!()
+    |> String.split("\n", trim: true)
+    |> Enum.with_index()
+    |> Map.new()
+  end
+end

--- a/test/slip39/cipher_test.exs
+++ b/test/slip39/cipher_test.exs
@@ -13,6 +13,13 @@ defmodule Bitcoinex.SLIP39.CipherTest do
         )
 
   describe "encrypt/5 and decrypt/5" do
+    test "reject odd-length and empty input at the function boundary" do
+      for bad <- [<<1>>, :binary.copy(<<1>>, 17), <<>>] do
+        assert_raise FunctionClauseError, fn -> Cipher.encrypt(bad, "", 0, 0, false) end
+        assert_raise FunctionClauseError, fn -> Cipher.decrypt(bad, "", 0, 0, false) end
+      end
+    end
+
     test "round-trip identity across ext, e, passphrase, and MS length" do
       for ms <- [@ms16, @ms32],
           passphrase <- ["", "TREZOR"],

--- a/test/slip39/gf256_test.exs
+++ b/test/slip39/gf256_test.exs
@@ -1,0 +1,210 @@
+defmodule Bitcoinex.SLIP39.GF256Test do
+  use ExUnit.Case
+  use ExUnitProperties
+
+  import Bitwise
+
+  alias Bitcoinex.SLIP39.GF256
+
+  doctest Bitcoinex.SLIP39.GF256
+
+  # Independent slow reference multiplication (shift-and-reduce over the
+  # Rijndael polynomial 0x11B) used to cross-check the table-based mul/2.
+  defp ref_mul(a, b) do
+    0..7
+    |> Enum.reduce({0, a}, fn i, {acc, shifted} ->
+      acc = if (b >>> i &&& 1) == 1, do: bxor(acc, shifted), else: acc
+      shifted = shifted <<< 1
+      shifted = if shifted > 0xFF, do: bxor(shifted, 0x11B), else: shifted
+      {acc, shifted}
+    end)
+    |> elem(0)
+  end
+
+  defp combinations(_list, 0), do: [[]]
+  defp combinations([], _k), do: []
+
+  defp combinations([head | tail], k) do
+    for(combo <- combinations(tail, k - 1), do: [head | combo]) ++ combinations(tail, k)
+  end
+
+  # f(x) = a2*x^2 + a1*x + a0 in GF(256), per byte lane.
+  defp eval_poly(coefficient_lanes, x) do
+    coefficient_lanes
+    |> Enum.map(fn [a2, a1, a0] ->
+      GF256.mul(a2, GF256.pow(x, 2))
+      |> GF256.add(GF256.mul(a1, x))
+      |> GF256.add(a0)
+    end)
+    |> :binary.list_to_bin()
+  end
+
+  describe "add/2" do
+    test "a + a == 0 for all a" do
+      for a <- 0..255, do: assert(GF256.add(a, a) == 0)
+    end
+
+    test "a + 0 == a for all a" do
+      for a <- 0..255, do: assert(GF256.add(a, 0) == a)
+    end
+  end
+
+  describe "mul/2" do
+    test "a * 0 == 0 and 0 * a == 0 for all a" do
+      for a <- 0..255 do
+        assert GF256.mul(a, 0) == 0
+        assert GF256.mul(0, a) == 0
+      end
+    end
+
+    test "a * 1 == a for all a" do
+      for a <- 0..255, do: assert(GF256.mul(a, 1) == a)
+    end
+
+    test "known AES vector: 0x57 * 0x13 == 0xFE (FIPS-197 sec. 4.2)" do
+      assert GF256.mul(0x57, 0x13) == 0xFE
+      assert GF256.mul(0x13, 0x57) == 0xFE
+    end
+
+    test "commutativity on a sample grid" do
+      for a <- [0, 1, 2, 3, 0x53, 0x57, 0xCA, 0xFF],
+          b <- [0, 1, 7, 0x13, 0x80, 0xFE, 0xFF] do
+        assert GF256.mul(a, b) == GF256.mul(b, a)
+      end
+    end
+
+    test "matches slow reference multiplication over the full field" do
+      for a <- 0..255, b <- 0..255 do
+        assert GF256.mul(a, b) == ref_mul(a, b)
+      end
+    end
+  end
+
+  describe "divide/2" do
+    test "mul(a, divide(1, a)) == 1 for all nonzero a" do
+      for a <- 1..255, do: assert(GF256.mul(a, GF256.divide(1, a)) == 1)
+    end
+
+    test "divide inverts mul on samples" do
+      for a <- [1, 2, 0x53, 0x57, 0xCA, 0xFF], b <- [1, 3, 0x13, 0x80, 0xFE] do
+        assert GF256.divide(GF256.mul(a, b), b) == a
+        assert GF256.mul(GF256.divide(a, b), b) == a
+      end
+    end
+
+    test "divide(0, b) == 0 for nonzero b" do
+      for b <- [1, 2, 0x13, 0xFF], do: assert(GF256.divide(0, b) == 0)
+    end
+
+    test "division by zero raises ArithmeticError" do
+      assert_raise ArithmeticError, fn -> GF256.divide(5, 0) end
+      assert_raise ArithmeticError, fn -> GF256.divide(0, 0) end
+    end
+  end
+
+  describe "pow/2" do
+    test "pow(a, 0) == 1 for all a" do
+      for a <- 0..255, do: assert(GF256.pow(a, 0) == 1)
+    end
+
+    test "pow(a, 1) == a for all a" do
+      for a <- 0..255, do: assert(GF256.pow(a, 1) == a)
+    end
+
+    test "exp/log table consistency across the full field" do
+      # pow via the tables must agree with repeated reference multiplication,
+      # and 3 must generate every nonzero element exactly once.
+      for a <- 0..255 do
+        assert GF256.pow(a, 2) == ref_mul(a, a)
+        assert GF256.pow(a, 3) == ref_mul(ref_mul(a, a), a)
+      end
+
+      powers_of_3 = Enum.map(0..254, &GF256.pow(3, &1))
+      assert Enum.sort(powers_of_3) == Enum.to_list(1..255)
+    end
+
+    test "negative exponent is the multiplicative inverse for nonzero a" do
+      for a <- [1, 2, 0x57, 0xFF], do: assert(GF256.mul(a, GF256.pow(a, -1)) == 1)
+    end
+
+    test "pow(0, n) == 0 for positive n and raises for negative n" do
+      assert GF256.pow(0, 5) == 0
+      assert_raise ArithmeticError, fn -> GF256.pow(0, -1) end
+    end
+  end
+
+  describe "interpolate/2" do
+    test "degree-0 (constant) polynomial is recovered exactly" do
+      points = [{1, <<0x2A, 0x07>>}, {2, <<0x2A, 0x07>>}]
+      assert GF256.interpolate(points, 0) == <<0x2A, 0x07>>
+      assert GF256.interpolate(points, 255) == <<0x2A, 0x07>>
+    end
+
+    test "degree-1 line is recovered exactly" do
+      # f(x) = a*x + b per byte lane
+      lanes = [{0x53, 0x11}, {0xCA, 0xFE}]
+
+      f = fn x ->
+        lanes
+        |> Enum.map(fn {a, b} -> GF256.add(GF256.mul(a, x), b) end)
+        |> :binary.list_to_bin()
+      end
+
+      points = [{0, f.(0)}, {1, f.(1)}]
+
+      for x <- [2, 3, 100, 254, 255] do
+        assert GF256.interpolate(points, x) == f.(x)
+      end
+    end
+
+    test "reconstructs a known polynomial's f(255) from T points" do
+      coefficient_lanes = [[0x53, 0xCA, 0x11], [0x02, 0x87, 0xFE]]
+      points = for x <- [0, 1, 2], do: {x, eval_poly(coefficient_lanes, x)}
+
+      assert GF256.interpolate(points, 255) == eval_poly(coefficient_lanes, 255)
+      assert GF256.interpolate(points, 254) == eval_poly(coefficient_lanes, 254)
+    end
+
+    test "result is independent of which T points are chosen" do
+      coefficient_lanes = [[0x53, 0xCA, 0x11], [0x02, 0x87, 0xFE]]
+      all_points = for x <- [0, 1, 2, 3, 4], do: {x, eval_poly(coefficient_lanes, x)}
+      expected = eval_poly(coefficient_lanes, 255)
+
+      for subset <- combinations(all_points, 3) do
+        assert GF256.interpolate(subset, 255) == expected
+      end
+    end
+
+    test "returns the matching y when x is one of the given points" do
+      points = [{5, <<1, 2, 3>>}, {9, <<4, 5, 6>>}]
+      assert GF256.interpolate(points, 9) == <<4, 5, 6>>
+    end
+  end
+
+  describe "field properties" do
+    property "mul is commutative" do
+      check all(a <- integer(0..255), b <- integer(0..255)) do
+        assert GF256.mul(a, b) == GF256.mul(b, a)
+      end
+    end
+
+    property "divide(mul(a, b), b) == a for nonzero b" do
+      check all(a <- integer(0..255), b <- integer(1..255)) do
+        assert GF256.divide(GF256.mul(a, b), b) == a
+      end
+    end
+
+    property "mul distributes over add" do
+      check all(a <- integer(0..255), b <- integer(0..255), c <- integer(0..255)) do
+        assert GF256.mul(a, GF256.add(b, c)) ==
+                 GF256.add(GF256.mul(a, b), GF256.mul(a, c))
+      end
+    end
+
+    property "pow(a, 255) == 1 for nonzero a (Fermat)" do
+      check all(a <- integer(1..255)) do
+        assert GF256.pow(a, 255) == 1
+      end
+    end
+  end
+end

--- a/test/slip39/gf256_test.exs
+++ b/test/slip39/gf256_test.exs
@@ -179,6 +179,16 @@ defmodule Bitcoinex.SLIP39.GF256Test do
       points = [{5, <<1, 2, 3>>}, {9, <<4, 5, 6>>}]
       assert GF256.interpolate(points, 9) == <<4, 5, 6>>
     end
+
+    test "points with unequal byte lengths raise ArgumentError" do
+      points = [{1, <<1, 2, 3>>}, {2, <<4, 5>>}]
+
+      assert_raise ArgumentError, fn -> GF256.interpolate(points, 0) end
+
+      # but the early keyfind path still returns a matching y directly,
+      # without needing the other lanes to line up
+      assert GF256.interpolate(points, 2) == <<4, 5>>
+    end
   end
 
   describe "field properties" do

--- a/test/slip39/shamir_test.exs
+++ b/test/slip39/shamir_test.exs
@@ -98,13 +98,17 @@ defmodule Bitcoinex.SLIP39.ShamirTest do
   end
 
   describe "recover_secret/2 failure modes" do
-    test "fewer than threshold shares -> {:error, :invalid_digest}" do
+    test "fewer than threshold shares -> {:error, :insufficient_shares}" do
       rng = make_rng(11)
       shares = Shamir.split_secret(3, 5, @secret_16, rng)
 
       for subset <- combinations(shares, 2) do
-        assert Shamir.recover_secret(3, subset) == {:error, :invalid_digest}
+        assert Shamir.recover_secret(3, subset) == {:error, :insufficient_shares}
       end
+
+      # empty share sets are rejected the same way, at both threshold branches
+      assert Shamir.recover_secret(3, []) == {:error, :insufficient_shares}
+      assert Shamir.recover_secret(1, []) == {:error, :insufficient_shares}
     end
 
     test "one corrupted share byte -> {:error, :invalid_digest}" do
@@ -160,6 +164,26 @@ defmodule Bitcoinex.SLIP39.ShamirTest do
       assert_raise FunctionClauseError, fn ->
         Shamir.split_secret(1, 17, @secret_16, rng)
       end
+    end
+
+    test "secret shorter than the digest length raises for threshold >= 2" do
+      rng = make_rng(31)
+
+      # threshold >= 2 needs a random_part of byte_size(secret) - 4 bytes;
+      # a secret shorter than 4 bytes would demand a negative-length draw
+      for tiny <- [<<>>, <<1>>, <<1, 2, 3>>] do
+        assert_raise FunctionClauseError, fn ->
+          Shamir.split_secret(2, 3, tiny, rng)
+        end
+      end
+
+      # exactly the digest length is the boundary and is allowed
+      assert [_ | _] = Shamir.split_secret(2, 3, <<1, 2, 3, 4>>, rng)
+    end
+
+    test "threshold == 1 accepts an arbitrarily short secret (no digest used)" do
+      rng = make_rng(37)
+      assert Shamir.split_secret(1, 3, <<9>>, rng) == [{0, <<9>>}, {1, <<9>>}, {2, <<9>>}]
     end
   end
 

--- a/test/slip39/shamir_test.exs
+++ b/test/slip39/shamir_test.exs
@@ -1,0 +1,213 @@
+defmodule Bitcoinex.SLIP39.ShamirTest do
+  use ExUnit.Case
+  use ExUnitProperties
+
+  import Bitwise
+
+  alias Bitcoinex.SLIP39.Shamir
+
+  doctest Bitcoinex.SLIP39.Shamir
+
+  @secret_16 Base.decode16!("0ff784df000c4380a5ed683491a8b87f", case: :lower)
+  @secret_32 Base.decode16!(
+               "989baf9dcaad5b10a5eec78afcaf0a1cc762c9e3d7cadef8aac343109fd90c69",
+               case: :lower
+             )
+
+  # Deterministic rng stub: a counter-keyed SHA-256 stream. Every call
+  # produces different (but reproducible) bytes; no CSPRNG is used in tests.
+  defp make_rng(seed) do
+    counter = :atomics.new(1, signed: false)
+
+    fn byte_count ->
+      call_index = :atomics.add_get(counter, 1, 1)
+      expand_bytes(<<seed::unsigned-64, call_index::unsigned-64>>, byte_count, <<>>)
+    end
+  end
+
+  defp expand_bytes(_key, byte_count, acc) when byte_size(acc) >= byte_count,
+    do: binary_part(acc, 0, byte_count)
+
+  defp expand_bytes(key, byte_count, acc) do
+    block = :crypto.hash(:sha256, [key, <<byte_size(acc)::unsigned-32>>])
+    expand_bytes(key, byte_count, acc <> block)
+  end
+
+  defp combinations(_list, 0), do: [[]]
+  defp combinations([], _k), do: []
+
+  defp combinations([head | tail], k) do
+    for(combo <- combinations(tail, k - 1), do: [head | combo]) ++ combinations(tail, k)
+  end
+
+  defp corrupt_byte({index, value}, byte_position, xor_value) do
+    <<prefix::binary-size(byte_position), byte, suffix::binary>> = value
+    {index, <<prefix::binary, bxor(byte, xor_value), suffix::binary>>}
+  end
+
+  # Deterministic random T-subset of 0..count-1: shuffle by a hash keyed on
+  # subset_seed and take the first `threshold` indices. Avoids
+  # StreamData.uniq_list_of/2, which exhausts when threshold is close to count.
+  defp subset_indices(count, threshold, subset_seed) do
+    0..(count - 1)
+    |> Enum.sort_by(&:erlang.phash2({subset_seed, &1}))
+    |> Enum.take(threshold)
+  end
+
+  describe "split_secret/4 with threshold == 1" do
+    test "all shares equal the secret" do
+      rng = make_rng(1)
+
+      for count <- [1, 3, 16] do
+        shares = Shamir.split_secret(1, count, @secret_16, rng)
+        assert length(shares) == count
+        assert shares == Enum.map(0..(count - 1), &{&1, @secret_16})
+      end
+    end
+
+    test "recover_secret/2 with threshold 1 returns the share value" do
+      assert Shamir.recover_secret(1, [{0, @secret_16}]) == {:ok, @secret_16}
+      assert Shamir.recover_secret(1, [{5, @secret_32}]) == {:ok, @secret_32}
+    end
+  end
+
+  describe "split/recover round-trip" do
+    test "recovers from every T-subset for (2,3), (3,5), (2,2), (16,16), 16- and 32-byte secrets" do
+      for {threshold, count} <- [{2, 3}, {3, 5}, {2, 2}, {16, 16}],
+          secret <- [@secret_16, @secret_32] do
+        rng = make_rng(threshold * 100 + count)
+        shares = Shamir.split_secret(threshold, count, secret, rng)
+
+        assert length(shares) == count
+        assert Enum.map(shares, &elem(&1, 0)) == Enum.to_list(0..(count - 1))
+        assert Enum.all?(shares, fn {_i, value} -> byte_size(value) == byte_size(secret) end)
+
+        for subset <- combinations(shares, threshold) do
+          assert Shamir.recover_secret(threshold, subset) == {:ok, secret},
+                 "failed for (#{threshold},#{count}) subset #{inspect(Enum.map(subset, &elem(&1, 0)))}"
+        end
+      end
+    end
+
+    test "recovery is independent of share order" do
+      rng = make_rng(7)
+      shares = Shamir.split_secret(3, 5, @secret_16, rng)
+      subset = shares |> Enum.take(3) |> Enum.reverse()
+      assert Shamir.recover_secret(3, subset) == {:ok, @secret_16}
+    end
+  end
+
+  describe "recover_secret/2 failure modes" do
+    test "fewer than threshold shares -> {:error, :invalid_digest}" do
+      rng = make_rng(11)
+      shares = Shamir.split_secret(3, 5, @secret_16, rng)
+
+      for subset <- combinations(shares, 2) do
+        assert Shamir.recover_secret(3, subset) == {:error, :invalid_digest}
+      end
+    end
+
+    test "one corrupted share byte -> {:error, :invalid_digest}" do
+      rng = make_rng(13)
+      shares = Shamir.split_secret(2, 3, @secret_16, rng)
+      [good, bad | _] = shares
+
+      corrupted = corrupt_byte(bad, 0, 0x01)
+      assert Shamir.recover_secret(2, [good, corrupted]) == {:error, :invalid_digest}
+
+      corrupted = corrupt_byte(bad, 15, 0x80)
+      assert Shamir.recover_secret(2, [good, corrupted]) == {:error, :invalid_digest}
+    end
+
+    test "shares from different splits -> {:error, :invalid_digest}" do
+      shares_a = Shamir.split_secret(2, 3, @secret_16, make_rng(17))
+      shares_b = Shamir.split_secret(2, 3, @secret_32 |> binary_part(0, 16), make_rng(19))
+
+      assert Shamir.recover_secret(2, [Enum.at(shares_a, 0), Enum.at(shares_b, 1)]) ==
+               {:error, :invalid_digest}
+    end
+  end
+
+  describe "create_digest/2 and valid_digest?/2" do
+    test "a created digest validates against its secret" do
+      random_part = make_rng(23).(12)
+      digest = Shamir.create_digest(random_part, @secret_16)
+
+      assert byte_size(digest) == 4 + byte_size(random_part)
+      assert <<_hmac_prefix::binary-size(4), ^random_part::binary>> = digest
+      assert Shamir.valid_digest?(digest, @secret_16)
+    end
+
+    test "digest matches HMAC-SHA256(random, secret) truncated to 4 bytes" do
+      random_part = <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12>>
+
+      <<expected::binary-size(4), _::binary>> =
+        :crypto.mac(:hmac, :sha256, random_part, @secret_16)
+
+      assert Shamir.create_digest(random_part, @secret_16) == expected <> random_part
+    end
+
+    test "tampered secret fails validation" do
+      random_part = make_rng(29).(12)
+      digest = Shamir.create_digest(random_part, @secret_16)
+
+      <<first, rest::binary>> = @secret_16
+      tampered_secret = <<bxor(first, 0xFF), rest::binary>>
+      refute Shamir.valid_digest?(digest, tampered_secret)
+    end
+
+    test "tampered digest share fails validation" do
+      random_part = make_rng(31).(12)
+      digest = Shamir.create_digest(random_part, @secret_16)
+
+      {_, tampered} = corrupt_byte({0, digest}, 2, 0x10)
+      refute Shamir.valid_digest?(tampered, @secret_16)
+    end
+  end
+
+  describe "properties" do
+    property "any T-subset of N shares recovers the secret" do
+      check all(
+              secret_length <- member_of([16, 32]),
+              secret <- binary(length: secret_length),
+              threshold <- integer(2..16),
+              count <- integer(threshold..16),
+              seed <- integer(0..0xFFFF_FFFF),
+              subset_seed <- integer(0..0xFFFF_FFFF)
+            ) do
+        rng = make_rng(seed)
+        shares = Shamir.split_secret(threshold, count, secret, rng)
+
+        subset =
+          Enum.map(subset_indices(count, threshold, subset_seed), &Enum.at(shares, &1))
+
+        assert Shamir.recover_secret(threshold, subset) == {:ok, secret}
+      end
+    end
+
+    property "corrupting one byte of one share in the subset -> {:error, :invalid_digest}" do
+      check all(
+              secret_length <- member_of([16, 32]),
+              secret <- binary(length: secret_length),
+              threshold <- integer(2..16),
+              count <- integer(threshold..16),
+              seed <- integer(0..0xFFFF_FFFF),
+              subset_seed <- integer(0..0xFFFF_FFFF),
+              corrupt_position <- integer(0..(threshold - 1)),
+              byte_position <- integer(0..(secret_length - 1)),
+              xor_value <- integer(1..255)
+            ) do
+        rng = make_rng(seed)
+        shares = Shamir.split_secret(threshold, count, secret, rng)
+
+        subset =
+          Enum.map(subset_indices(count, threshold, subset_seed), &Enum.at(shares, &1))
+
+        corrupted = corrupt_byte(Enum.at(subset, corrupt_position), byte_position, xor_value)
+        subset = List.replace_at(subset, corrupt_position, corrupted)
+
+        assert Shamir.recover_secret(threshold, subset) == {:error, :invalid_digest}
+      end
+    end
+  end
+end

--- a/test/slip39/shamir_test.exs
+++ b/test/slip39/shamir_test.exs
@@ -146,6 +146,19 @@ defmodule Bitcoinex.SLIP39.ShamirTest do
       assert Shamir.recover_secret(2, [share_a, {index_a, value_b}]) ==
                {:error, :duplicate_share_indices}
     end
+
+    test "share index outside 0..15 -> {:error, :invalid_share_index}" do
+      rng = make_rng(41)
+      [share_a, {_index_b, value_b} | _] = Shamir.split_secret(2, 3, @secret_16, rng)
+
+      # the reserved anchor indices (digest 254, secret 255) must not be usable
+      # as share indices: interpolate/2's keyfind fast path would otherwise hand
+      # back a raw share value in place of an interpolated secret/digest.
+      for bad_index <- [16, 254, 255] do
+        assert Shamir.recover_secret(2, [share_a, {bad_index, value_b}]) ==
+                 {:error, :invalid_share_index}
+      end
+    end
   end
 
   describe "split_secret/4 contract guards" do
@@ -244,6 +257,10 @@ defmodule Bitcoinex.SLIP39.ShamirTest do
       end
     end
 
+    # A corrupted subset could in principle pass the digest check by chance,
+    # but the digest is 4 bytes so that false-accept probability is ~2^-32 per
+    # generated case; across the property's runs a spurious failure here is
+    # astronomically unlikely, not a real flake.
     property "corrupting one byte of one share in the subset -> {:error, :invalid_digest}" do
       check all(
               secret_length <- member_of([16, 32]),

--- a/test/slip39/shamir_test.exs
+++ b/test/slip39/shamir_test.exs
@@ -126,6 +126,41 @@ defmodule Bitcoinex.SLIP39.ShamirTest do
       assert Shamir.recover_secret(2, [Enum.at(shares_a, 0), Enum.at(shares_b, 1)]) ==
                {:error, :invalid_digest}
     end
+
+    test "duplicate share indices -> {:error, :duplicate_share_indices}" do
+      rng = make_rng(23)
+      [share_a, share_b | _] = Shamir.split_secret(2, 3, @secret_16, rng)
+
+      # identical duplicate
+      assert Shamir.recover_secret(2, [share_a, share_a]) ==
+               {:error, :duplicate_share_indices}
+
+      # same index, conflicting values
+      {index_a, _value_a} = share_a
+      {_index_b, value_b} = share_b
+
+      assert Shamir.recover_secret(2, [share_a, {index_a, value_b}]) ==
+               {:error, :duplicate_share_indices}
+    end
+  end
+
+  describe "split_secret/4 contract guards" do
+    test "count above 16 raises instead of leaking anchor shares" do
+      # an uncapped count would emit the secret verbatim at index 255
+      rng = make_rng(29)
+
+      assert_raise FunctionClauseError, fn ->
+        Shamir.split_secret(2, 256, @secret_16, rng)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        Shamir.split_secret(2, 17, @secret_16, rng)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        Shamir.split_secret(1, 17, @secret_16, rng)
+      end
+    end
   end
 
   describe "create_digest/2 and valid_digest?/2" do


### PR DESCRIPTION
Stack: S0 → S1 → S2 → **S3** → S4 → S5 → S6 (spec §3.4, §3.5)

- `Bitcoinex.SLIP39.GF256`: Rijndael-poly (0x11B) field; exp/log tables generated in the module body at compile time with compile-time assertions that the generator-3 cycle is exactly 255; `add/mul/divide/pow/interpolate` (byte-lane Lagrange)
- `Bitcoinex.SLIP39.Shamir`: `split_secret/4` (digest share at 254, secret at 255, HMAC-SHA256 digest per SLIP-39), `recover_secret/2` rejecting bad share sets via `:invalid_digest`
- FIPS-197 `0x57·0x13=0xFE` KAT verified against an independent slow multiply over the full 256×256 field; algebraic properties (commutativity, distributivity, Fermat); every-T-subset recovery for (2,3)/(3,5)/(2,2)/(16,16) on 16- and 32-byte secrets; corruption/under-threshold rejection. Deterministic rng stub in all tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)