### PR TITLE
S5: SLIP-39 RS1024 encoding + Share codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - BIP-39 mnemonic support (`Bitcoinex.BIP39`): entropy-to-mnemonic encoding and decoding with checksum validation, NFKD-normalized seed derivation via PBKDF2-HMAC-SHA512, and master extended private key derivation.
+- SLIP-39 Shamir's Secret-Sharing mnemonic support (`Bitcoinex.SLIP39`): two-level (group/member) secret splitting via `generate_mnemonics/4` and recovery via `combine_mnemonics/2`, with passphrase encryption (four-round Feistel over PBKDF2-HMAC-SHA256), GF(256) Shamir sharing with digest verification, RS1024 checksums, and the extendable share-set flag. Verified against all 45 official SLIP-0039 test vectors.
 
 ## [0.1.8] - 2024-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-01
 ### Added
 - BIP-39 mnemonic support (`Bitcoinex.BIP39`): entropy-to-mnemonic encoding and decoding with checksum validation, NFKD-normalized seed derivation via PBKDF2-HMAC-SHA512, and master extended private key derivation.
 - SLIP-39 Shamir's Secret-Sharing mnemonic support (`Bitcoinex.SLIP39`): two-level (group/member) secret splitting via `generate_mnemonics/4` and recovery via `combine_mnemonics/2`, with passphrase encryption (four-round Feistel over PBKDF2-HMAC-SHA256), GF(256) Shamir sharing with digest verification, RS1024 checksums, and the extendable share-set flag. Verified against all 45 official SLIP-0039 test vectors.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Documentation is available on [hexdocs.pm](https://hexdocs.pm/bitcoinex/api-refe
 * Support for standard on-chain scripts (P2PKH..P2WPKH) and Bolt#11 Lightning Invoices.
 * Transaction serialization.
 * Basic PSBT (BIP174) parsing.
+* BIP39 mnemonic seed phrases: entropy encoding/decoding and seed derivation.
+* SLIP39 Shamir's Secret-Sharing mnemonics: split and recover master secrets.
 
 ## Usage
 

--- a/docs/specs/slip39-bip39-primitives.md
+++ b/docs/specs/slip39-bip39-primitives.md
@@ -224,7 +224,7 @@ Note thresholds/counts are stored **1-based** in the struct; the wire format sto
 ```
 
 **`generate_mnemonics/4`.**
-1. Validate: `master_secret` byte length even and `≥ 16` (`:invalid_secret_length`); `1 ≤ group_threshold ≤ length(groups) ≤ 16` (`:invalid_group_threshold`); each `{t,n}` with `1 ≤ t ≤ n ≤ 16`, and **not** (`t == 1 and n > 1`) (`:invalid_member_threshold`); passphrase contains only printable ASCII (code points 32–126, per SLIP-39 — `String.to_charlist |> Enum.all?(&(&1 in 32..126))`) (`:invalid_passphrase`).
+1. Validate: `master_secret` byte length even and `≥ 16` (`:invalid_secret_length`); `1 ≤ group_threshold ≤ length(groups) ≤ 16` (`:invalid_group_threshold`); each `{t,n}` with `1 ≤ t ≤ n ≤ 16`, and **not** (`t == 1 and n > 1`) (`:invalid_member_threshold`); passphrase contains only printable ASCII (code points 32–126, per SLIP-39 — `String.to_charlist |> Enum.all?(&(&1 in 32..126))`) (`:invalid_passphrase`). Additionally, `identifier` opt must be `nil` or an integer in `0..0x7FFF` (`:invalid_identifier`) and `iteration_exponent` an integer in `0..15` (`:invalid_iteration_exponent`) — the wire format truncates these to 15/4 bits, so unvalidated out-of-range values would encode shares whose recombination silently yields a different master secret.
 2. `identifier` = opt or `:rand`-free draw of 15 bits from `rng` (`<<id::15, _::1>> = rng.(2)`).
 3. `ems = Cipher.encrypt(master_secret, passphrase, e, id, ext)`.
 4. `group_shares = Shamir.split_secret(group_threshold, length(groups), ems, rng)` → `[{group_index, group_value}]`.
@@ -301,7 +301,7 @@ Word lists and checksum logic otherwise stay scheme-specific (RS1024 ≠ bech32 
 - All `@`-constants from §3.3.
 - `@type group_spec`, `generate_mnemonics/4`, `combine_mnemonics/2` (§3.9).
 - private validators (`validate_secret/1`, `validate_groups/2`), grouping/consistency helpers.
-- Error atoms: `:invalid_secret_length`, `:invalid_group_threshold`, `:invalid_member_threshold`, `:invalid_passphrase`, `:mismatching_shares`, `:insufficient_groups`, `:too_many_groups`, `:insufficient_member_shares`, `:too_many_member_shares`, `:duplicate_member_index`, `:empty_mnemonic_set`.
+- Error atoms: `:invalid_secret_length`, `:invalid_group_threshold`, `:invalid_member_threshold`, `:invalid_passphrase`, `:mismatching_shares`, `:insufficient_groups`, `:too_many_groups`, `:insufficient_member_shares`, `:too_many_member_shares`, `:duplicate_member_index`, `:empty_mnemonic_set`, `:invalid_identifier`, `:invalid_iteration_exponent`.
 
 ### `lib/slip39/gf256.ex` — `Bitcoinex.SLIP39.GF256` (new)
 - `@exp_table`, `@log_table` (generated in the module body per §3.4 — not via a same-module `defp`; generator 3, poly `0x11B`).

--- a/lib/slip39.ex
+++ b/lib/slip39.ex
@@ -68,7 +68,11 @@ defmodule Bitcoinex.SLIP39 do
   `1 <= group_threshold <= length(groups) <= 16`),
   `:invalid_member_threshold` (each spec requires `1 <= t <= n <= 16` and
   forbids `t == 1` with `n > 1`), `:invalid_passphrase` (printable ASCII,
-  code points 32-126, only).
+  code points 32-126, only), `:invalid_identifier` (integer in `0..0x7FFF`),
+  `:invalid_iteration_exponent` (integer in `0..15`). The identifier and
+  iteration exponent are range-checked because the wire format truncates
+  them to 15 and 4 bits: unvalidated out-of-range values would encode
+  shares whose recombination silently yields a different master secret.
   """
   @spec generate_mnemonics(1..16, [group_spec()], binary(), keyword()) ::
           {:ok, [[String.t()]]} | {:error, atom()}
@@ -81,8 +85,14 @@ defmodule Bitcoinex.SLIP39 do
     with :ok <- validate_secret(master_secret),
          :ok <- validate_group_threshold(group_threshold, length(groups)),
          :ok <- validate_groups(groups),
-         :ok <- validate_passphrase(passphrase) do
-      identifier = Keyword.get(opts, :identifier) || random_identifier(rng)
+         :ok <- validate_passphrase(passphrase),
+         :ok <- validate_identifier(Keyword.get(opts, :identifier)),
+         :ok <- validate_iteration_exponent(iteration_exponent) do
+      identifier =
+        case Keyword.get(opts, :identifier) do
+          nil -> random_identifier(rng)
+          identifier -> identifier
+        end
 
       ems =
         Cipher.encrypt(master_secret, passphrase, iteration_exponent, identifier, extendable)
@@ -192,6 +202,20 @@ defmodule Bitcoinex.SLIP39 do
       {:error, :invalid_passphrase}
     end
   end
+
+  # the wire format truncates the identifier to 15 bits and the iteration
+  # exponent to 4 bits; out-of-range values would encrypt with parameters
+  # that differ from the encoded ones, so recombination would silently
+  # yield a different master secret
+  defp validate_identifier(nil), do: :ok
+
+  defp validate_identifier(identifier) when is_integer(identifier) and identifier in 0..0x7FFF,
+    do: :ok
+
+  defp validate_identifier(_identifier), do: {:error, :invalid_identifier}
+
+  defp validate_iteration_exponent(e) when is_integer(e) and e in 0..15, do: :ok
+  defp validate_iteration_exponent(_e), do: {:error, :invalid_iteration_exponent}
 
   defp validate_non_empty([]), do: {:error, :empty_mnemonic_set}
   defp validate_non_empty(_mnemonics), do: :ok

--- a/lib/slip39.ex
+++ b/lib/slip39.ex
@@ -1,0 +1,262 @@
+defmodule Bitcoinex.SLIP39 do
+  @moduledoc """
+  SLIP-0039: Shamir's Secret-Sharing for Mnemonic Codes.
+
+  Splits a master secret into a two-level hierarchy of mnemonic shares and
+  recombines them. The master secret is first encrypted under a passphrase
+  (`Bitcoinex.SLIP39.Cipher`), then split into group shares, each of which is
+  split into member shares (`Bitcoinex.SLIP39.Shamir`); each member share is
+  encoded as a mnemonic (`Bitcoinex.SLIP39.Share`). Recovering the master
+  secret requires exactly `group_threshold` groups, each contributing exactly
+  its member threshold of shares.
+
+  Note that SLIP-39 offers plausible deniability: combining a valid share set
+  with a wrong passphrase does not fail, it silently yields a different
+  master secret. The caller is responsible for passphrase correctness.
+
+  Elixir binaries are immutable and garbage-collected, so this library cannot
+  guarantee zeroization of secrets or passphrases in memory.
+
+  ## Examples
+
+      iex> rng = fn byte_count -> :binary.copy(<<7>>, byte_count) end
+      iex> master_secret = :binary.copy(<<0xAB>>, 16)
+      iex> {:ok, [[share_a, share_b, _share_c]]} =
+      ...>   Bitcoinex.SLIP39.generate_mnemonics(1, [{2, 3}], master_secret, rng: rng)
+      iex> {:ok, recovered} = Bitcoinex.SLIP39.combine_mnemonics([share_a, share_b])
+      iex> recovered == master_secret
+      true
+  """
+
+  alias Bitcoinex.SLIP39.{Cipher, Shamir, Share}
+
+  @id_length_bits 15
+  @max_share_count 16
+  @min_strength_bits 128
+  @min_strength_bytes div(@min_strength_bits, 8)
+
+  @typedoc """
+  A group specification: `{member_threshold, member_count}`. The group is
+  split into `member_count` shares, any `member_threshold` of which recover
+  the group share.
+  """
+  @type group_spec :: {member_threshold :: 1..16, member_count :: 1..16}
+
+  @doc """
+  generate_mnemonics splits `master_secret` into SLIP-39 mnemonic shares.
+
+  The secret is split into `length(groups)` group shares, any
+  `group_threshold` of which recover it; each group `i` is split into member
+  shares per its `{member_threshold, member_count}` spec. Returns
+  `{:ok, groups_of_mnemonics}` where the i-th element is the list of mnemonic
+  strings for the i-th group spec.
+
+  Options:
+
+  - `:passphrase` (default `""`) — printable-ASCII encryption passphrase.
+  - `:extendable` (default `true`) — whether the share set is extendable
+    (the identifier is then not used as an encryption salt).
+  - `:iteration_exponent` (default `0`) — PBKDF2 cost, `2500 <<< e` per round.
+  - `:rng` (default `&:crypto.strong_rand_bytes/1`) — randomness source,
+    `byte_count -> binary`. Injectable ONLY for deterministic tests;
+    production callers must use a CSPRNG.
+  - `:identifier` (default `nil`) — 15-bit share-set identifier; drawn from
+    `rng` when `nil`.
+
+  Errors: `:invalid_secret_length` (must be at least 16 bytes and of even
+  length), `:invalid_group_threshold` (requires
+  `1 <= group_threshold <= length(groups) <= 16`),
+  `:invalid_member_threshold` (each spec requires `1 <= t <= n <= 16` and
+  forbids `t == 1` with `n > 1`), `:invalid_passphrase` (printable ASCII,
+  code points 32-126, only).
+  """
+  @spec generate_mnemonics(1..16, [group_spec()], binary(), keyword()) ::
+          {:ok, [[String.t()]]} | {:error, atom()}
+  def generate_mnemonics(group_threshold, groups, master_secret, opts \\ []) do
+    passphrase = Keyword.get(opts, :passphrase, "")
+    extendable = Keyword.get(opts, :extendable, true)
+    iteration_exponent = Keyword.get(opts, :iteration_exponent, 0)
+    rng = Keyword.get(opts, :rng, &:crypto.strong_rand_bytes/1)
+
+    with :ok <- validate_secret(master_secret),
+         :ok <- validate_group_threshold(group_threshold, length(groups)),
+         :ok <- validate_groups(groups),
+         :ok <- validate_passphrase(passphrase) do
+      identifier = Keyword.get(opts, :identifier) || random_identifier(rng)
+
+      ems =
+        Cipher.encrypt(master_secret, passphrase, iteration_exponent, identifier, extendable)
+
+      mnemonics =
+        group_threshold
+        |> Shamir.split_secret(length(groups), ems, rng)
+        |> Enum.zip(groups)
+        |> Enum.map(fn {{group_index, group_value}, {member_threshold, member_count}} ->
+          member_threshold
+          |> Shamir.split_secret(member_count, group_value, rng)
+          |> Enum.map(fn {member_index, share_value} ->
+            Share.encode(%Share{
+              identifier: identifier,
+              extendable: extendable,
+              iteration_exponent: iteration_exponent,
+              group_index: group_index,
+              group_threshold: group_threshold,
+              group_count: length(groups),
+              member_index: member_index,
+              member_threshold: member_threshold,
+              share_value: share_value
+            })
+          end)
+        end)
+
+      {:ok, mnemonics}
+    end
+  end
+
+  @doc """
+  combine_mnemonics recovers the master secret from SLIP-39 mnemonics.
+
+  The share set must contain exactly `group_threshold` distinct groups, and
+  each group must contribute exactly its member threshold of shares with
+  distinct member indices.
+
+  A wrong passphrase does not fail: it yields a different master secret
+  (SLIP-39 plausible deniability), so the caller must verify the result.
+
+  Errors: any `Bitcoinex.SLIP39.Share.decode/1` error (propagated as-is),
+  `:invalid_passphrase`, `:empty_mnemonic_set`, `:mismatching_shares`
+  (shares disagree on identifier, extendable flag, iteration exponent, group
+  threshold, group count, share value length, or member threshold within a
+  group), `:insufficient_groups`, `:too_many_groups`,
+  `:insufficient_member_shares`, `:too_many_member_shares`,
+  `:duplicate_member_index`, `:invalid_digest` (recovered share set is
+  inconsistent or corrupted).
+  """
+  @spec combine_mnemonics([String.t()], binary()) :: {:ok, binary()} | {:error, atom()}
+  def combine_mnemonics(mnemonics, passphrase \\ "") do
+    with :ok <- validate_passphrase(passphrase),
+         :ok <- validate_non_empty(mnemonics),
+         {:ok, shares} <- decode_all(mnemonics),
+         :ok <- validate_consistency(shares),
+         share = hd(shares),
+         {:ok, groups} <- collect_groups(shares, share.group_threshold),
+         {:ok, group_points} <- recover_group_points(groups),
+         {:ok, ems} <- Shamir.recover_secret(share.group_threshold, group_points) do
+      {:ok,
+       Cipher.decrypt(
+         ems,
+         passphrase,
+         share.iteration_exponent,
+         share.identifier,
+         share.extendable
+       )}
+    end
+  end
+
+  defp validate_secret(master_secret)
+       when is_binary(master_secret) and byte_size(master_secret) >= @min_strength_bytes and
+              rem(byte_size(master_secret), 2) == 0,
+       do: :ok
+
+  defp validate_secret(_master_secret), do: {:error, :invalid_secret_length}
+
+  defp validate_group_threshold(group_threshold, group_count)
+       when group_threshold >= 1 and group_threshold <= group_count and
+              group_count <= @max_share_count,
+       do: :ok
+
+  defp validate_group_threshold(_group_threshold, _group_count),
+    do: {:error, :invalid_group_threshold}
+
+  defp validate_groups(groups) do
+    if Enum.all?(groups, &valid_group_spec?/1) do
+      :ok
+    else
+      {:error, :invalid_member_threshold}
+    end
+  end
+
+  # A member threshold of 1 with more than one share is forbidden: every
+  # share would be the group secret verbatim, silently defeating sharing.
+  defp valid_group_spec?({1, member_count}), do: member_count == 1
+
+  defp valid_group_spec?({member_threshold, member_count}),
+    do:
+      member_threshold >= 1 and member_threshold <= member_count and
+        member_count <= @max_share_count
+
+  defp validate_passphrase(passphrase) when is_binary(passphrase) do
+    if passphrase |> :binary.bin_to_list() |> Enum.all?(&(&1 in 32..126)) do
+      :ok
+    else
+      {:error, :invalid_passphrase}
+    end
+  end
+
+  defp validate_non_empty([]), do: {:error, :empty_mnemonic_set}
+  defp validate_non_empty(_mnemonics), do: :ok
+
+  defp random_identifier(rng) do
+    <<identifier::size(@id_length_bits), _::1>> = rng.(2)
+    identifier
+  end
+
+  defp decode_all(mnemonics) do
+    Enum.reduce_while(mnemonics, {:ok, []}, fn mnemonic, {:ok, shares} ->
+      case Share.decode(mnemonic) do
+        {:ok, share} -> {:cont, {:ok, [share | shares]}}
+        {:error, _reason} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_consistency(shares) do
+    parameters =
+      Enum.map(shares, fn share ->
+        {share.identifier, share.extendable, share.iteration_exponent, share.group_threshold,
+         share.group_count, byte_size(share.share_value)}
+      end)
+
+    case Enum.uniq(parameters) do
+      [_common] -> :ok
+      _mismatching -> {:error, :mismatching_shares}
+    end
+  end
+
+  defp collect_groups(shares, group_threshold) do
+    groups = Enum.group_by(shares, & &1.group_index)
+
+    cond do
+      map_size(groups) < group_threshold -> {:error, :insufficient_groups}
+      map_size(groups) > group_threshold -> {:error, :too_many_groups}
+      true -> validate_group_members(Map.values(groups), groups)
+    end
+  end
+
+  defp validate_group_members([], groups), do: {:ok, groups}
+
+  defp validate_group_members([members | rest], groups) do
+    thresholds = members |> Enum.map(& &1.member_threshold) |> Enum.uniq()
+    member_indices = Enum.map(members, & &1.member_index)
+    member_count = length(members)
+
+    cond do
+      length(thresholds) > 1 -> {:error, :mismatching_shares}
+      length(Enum.uniq(member_indices)) != member_count -> {:error, :duplicate_member_index}
+      member_count < hd(thresholds) -> {:error, :insufficient_member_shares}
+      member_count > hd(thresholds) -> {:error, :too_many_member_shares}
+      true -> validate_group_members(rest, groups)
+    end
+  end
+
+  defp recover_group_points(groups) do
+    Enum.reduce_while(groups, {:ok, []}, fn {group_index, members}, {:ok, points} ->
+      member_points = Enum.map(members, &{&1.member_index, &1.share_value})
+
+      case Shamir.recover_secret(hd(members).member_threshold, member_points) do
+        {:ok, group_value} -> {:cont, {:ok, [{group_index, group_value} | points]}}
+        {:error, _reason} = err -> {:halt, err}
+      end
+    end)
+  end
+end

--- a/lib/slip39/encoding.ex
+++ b/lib/slip39/encoding.ex
@@ -1,0 +1,120 @@
+defmodule Bitcoinex.SLIP39.Encoding do
+  @moduledoc """
+  SLIP-39 RS1024 checksum and word packing.
+
+  Implements the Reed-Solomon code over GF(1024) used by SLIP-39 mnemonics
+  (guarantees detection of up to 3 word errors) and the conversion between
+  10-bit word indices and words from the SLIP-39 word list.
+  """
+
+  import Bitwise
+
+  @wordlist_path Path.join(__DIR__, "../../priv/slip39_english.txt")
+  @external_resource @wordlist_path
+  {words, index} = Bitcoinex.Wordlist.load!(@wordlist_path, 1024)
+  @wordlist words
+  @word_index index
+
+  @customization_string_orig "shamir"
+  @customization_string_extendable "shamir_extendable"
+
+  @gen [
+    0xE0E040,
+    0x1C1C080,
+    0x3838100,
+    0x7070200,
+    0xE0E0009,
+    0x1C0C2412,
+    0x38086C24,
+    0x3090FC48,
+    0x21B1F890,
+    0x3F3F120
+  ]
+
+  @doc """
+  rs1024_polymod computes the RS1024 polynomial modulus over a list of
+  10-bit values, mirroring the bech32 polymod but with the SLIP-39
+  generator over GF(1024).
+  """
+  @spec rs1024_polymod(list(non_neg_integer())) :: non_neg_integer()
+  def rs1024_polymod(values) do
+    Enum.reduce(
+      values,
+      1,
+      fn value, acc ->
+        b = acc >>> 20
+        acc = Bitwise.bxor((acc &&& 0xFFFFF) <<< 10, value)
+
+        @gen
+        |> Enum.with_index()
+        |> Enum.reduce(acc, fn {gen_val, i}, in_acc ->
+          right_side =
+            if (b >>> i &&& 1) != 0 do
+              gen_val
+            else
+              0
+            end
+
+          Bitwise.bxor(in_acc, right_side)
+        end)
+      end
+    )
+  end
+
+  @doc """
+  rs1024_create_checksum returns the 3 checksum words (10-bit values) for
+  the given data words. `ext` selects the customization string:
+  "shamir_extendable" when true, "shamir" otherwise.
+  """
+  @spec rs1024_create_checksum(list(0..1023), boolean()) :: list(0..1023)
+  def rs1024_create_checksum(data, ext) do
+    values = customization_values(ext) ++ data ++ [0, 0, 0]
+    poly = values |> rs1024_polymod() |> Bitwise.bxor(1)
+    for i <- 0..2, do: poly >>> (10 * (2 - i)) &&& 1023
+  end
+
+  @doc """
+  rs1024_verify_checksum returns true if the data words (including the
+  trailing 3 checksum words) have a valid RS1024 checksum under the
+  customization string selected by `ext`.
+  """
+  @spec rs1024_verify_checksum(list(0..1023), boolean()) :: boolean()
+  def rs1024_verify_checksum(data, ext) do
+    rs1024_polymod(customization_values(ext) ++ data) == 1
+  end
+
+  @doc """
+  indices_to_words maps each 10-bit word index to its SLIP-39 word.
+  """
+  @spec indices_to_words(list(0..1023)) :: list(String.t())
+  def indices_to_words(indices) do
+    Enum.map(indices, &elem(@wordlist, &1))
+  end
+
+  @doc """
+  words_to_indices maps each SLIP-39 word to its 10-bit index. Returns
+  `{:error, :word_not_in_list}` if any word is not in the word list.
+  """
+  @spec words_to_indices(list(String.t())) ::
+          {:ok, list(0..1023)} | {:error, :word_not_in_list}
+  def words_to_indices(words) do
+    words
+    |> Enum.reduce_while([], fn word, acc ->
+      case Map.fetch(@word_index, word) do
+        {:ok, idx} -> {:cont, [idx | acc]}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      :error -> {:error, :word_not_in_list}
+      indices -> {:ok, Enum.reverse(indices)}
+    end
+  end
+
+  defp customization_values(ext) do
+    customization =
+      if ext, do: @customization_string_extendable, else: @customization_string_orig
+
+    :binary.bin_to_list(customization)
+  end
+end

--- a/lib/slip39/share.ex
+++ b/lib/slip39/share.ex
@@ -1,0 +1,154 @@
+defmodule Bitcoinex.SLIP39.Share do
+  @moduledoc """
+  A single SLIP-39 share and its mnemonic codec.
+
+  The struct stores thresholds and counts 1-based; the wire format stores
+  them minus 1 in 4 bits each. `group_index` and `member_index` are stored
+  as-is (0-based x-coordinates).
+  """
+
+  import Bitwise
+
+  alias Bitcoinex.SLIP39.Encoding
+  alias Bitcoinex.Utils
+
+  @radix_bits 10
+  @id_length_bits 15
+  @checksum_length_words 3
+  @metadata_length_words 7
+  @min_mnemonic_length_words 20
+
+  @enforce_keys [
+    :identifier,
+    :extendable,
+    :iteration_exponent,
+    :group_index,
+    :group_threshold,
+    :group_count,
+    :member_index,
+    :member_threshold,
+    :share_value
+  ]
+  defstruct [
+    :identifier,
+    :extendable,
+    :iteration_exponent,
+    :group_index,
+    :group_threshold,
+    :group_count,
+    :member_index,
+    :member_threshold,
+    :share_value
+  ]
+
+  @type t :: %__MODULE__{
+          identifier: 0..0x7FFF,
+          extendable: boolean(),
+          iteration_exponent: 0..15,
+          group_index: 0..15,
+          group_threshold: 1..16,
+          group_count: 1..16,
+          member_index: 0..15,
+          member_threshold: 1..16,
+          share_value: binary()
+        }
+
+  @doc """
+  encode serializes a share to its space-joined mnemonic string. It cannot
+  fail on a well-formed struct: all fields are range-constrained and
+  `share_value` is a whole number of bytes.
+  """
+  @spec encode(t()) :: String.t()
+  def encode(%__MODULE__{} = share) do
+    pad_bits = rem(@radix_bits - rem(bit_size(share.share_value), @radix_bits), @radix_bits)
+    ext_bit = if share.extendable, do: 1, else: 0
+    group_threshold_minus1 = share.group_threshold - 1
+    group_count_minus1 = share.group_count - 1
+    member_threshold_minus1 = share.member_threshold - 1
+
+    data_bits =
+      <<share.identifier::15, ext_bit::1, share.iteration_exponent::4, share.group_index::4,
+        group_threshold_minus1::4, group_count_minus1::4, share.member_index::4,
+        member_threshold_minus1::4, 0::size(pad_bits), share.share_value::binary>>
+
+    data_words = for <<idx::10 <- data_bits>>, do: idx
+    words = data_words ++ Encoding.rs1024_create_checksum(data_words, share.extendable)
+
+    words
+    |> Encoding.indices_to_words()
+    |> Enum.join(" ")
+  end
+
+  @doc """
+  decode parses a space-joined mnemonic string into a share, verifying the
+  RS1024 checksum, minimum length, padding, and group threshold.
+  """
+  @spec decode(String.t()) :: {:ok, t()} | {:error, atom()}
+  def decode(mnemonic) when is_binary(mnemonic) do
+    with {:ok, words} <- Encoding.words_to_indices(String.split(mnemonic)),
+         :ok <- validate_length(words),
+         :ok <- verify_checksum(words) do
+      words
+      |> Enum.take(length(words) - @checksum_length_words)
+      |> unpack(length(words))
+    end
+  end
+
+  defp validate_length(words) when length(words) >= @min_mnemonic_length_words, do: :ok
+  defp validate_length(_words), do: {:error, :invalid_mnemonic_length}
+
+  # The extendable bit selects the RS1024 customization string, so it is
+  # peeked from the raw words before the checksum can be verified: it is
+  # bit 15 of the 20 bits formed by the first two words.
+  defp verify_checksum([word0, word1 | _] = words) do
+    ext_bit = (word0 <<< @radix_bits ||| word1) >>> 4 &&& 1
+
+    if Encoding.rs1024_verify_checksum(words, ext_bit == 1) do
+      :ok
+    else
+      {:error, :invalid_checksum}
+    end
+  end
+
+  defp unpack(data_words, word_count) do
+    value_words = word_count - @metadata_length_words
+    pad_bits = rem(value_words * @radix_bits, 16)
+
+    if pad_bits > 8 do
+      # Rules out e.g. 21-word mnemonics, where rem(140, 16) == 12.
+      {:error, :invalid_padding}
+    else
+      # pad_bits <= 8 guarantees the trailing share value is a whole
+      # number of bytes, so this match cannot fail.
+      <<identifier::size(@id_length_bits), ext_bit::1, iteration_exponent::4, group_index::4,
+        group_threshold_minus1::4, group_count_minus1::4, member_index::4,
+        member_threshold_minus1::4, padding::size(pad_bits),
+        share_value::binary>> = Utils.int_list_to_bits(data_words, @radix_bits)
+
+      with :ok <- validate_padding(padding),
+           :ok <- validate_group_threshold(group_threshold_minus1, group_count_minus1) do
+        {:ok,
+         %__MODULE__{
+           identifier: identifier,
+           extendable: ext_bit == 1,
+           iteration_exponent: iteration_exponent,
+           group_index: group_index,
+           group_threshold: group_threshold_minus1 + 1,
+           group_count: group_count_minus1 + 1,
+           member_index: member_index,
+           member_threshold: member_threshold_minus1 + 1,
+           share_value: share_value
+         }}
+      end
+    end
+  end
+
+  defp validate_padding(0), do: :ok
+  defp validate_padding(_padding), do: {:error, :invalid_padding}
+
+  defp validate_group_threshold(group_threshold_minus1, group_count_minus1)
+       when group_threshold_minus1 > group_count_minus1,
+       do: {:error, :invalid_group_threshold}
+
+  defp validate_group_threshold(_group_threshold_minus1, _group_count_minus1), do: :ok
+end

--- a/lib/slip39/share.ex
+++ b/lib/slip39/share.ex
@@ -54,25 +54,47 @@ defmodule Bitcoinex.SLIP39.Share do
         }
 
   @doc """
-  encode serializes a share to its space-joined mnemonic string. It cannot
-  fail on a well-formed struct: all fields are range-constrained and
-  `share_value` is a whole number of bytes.
+  encode serializes a share to its space-joined mnemonic string.
+
+  It cannot fail on a well-formed struct, and the guard enforces exactly
+  what "well-formed" means: every field is within the range its wire
+  encoding allows, and `share_value` is a SLIP-39-valid length — a whole
+  number of bytes, at least 128 bits (16 bytes), and a multiple of 16 bits
+  (even byte count). An out-of-range struct is a programmer error and
+  raises `FunctionClauseError` rather than silently truncating a field or
+  emitting a mnemonic that cannot be decoded back.
   """
   @spec encode(t()) :: String.t()
-  def encode(%__MODULE__{} = share) do
-    pad_bits = rem(@radix_bits - rem(bit_size(share.share_value), @radix_bits), @radix_bits)
-    ext_bit = if share.extendable, do: 1, else: 0
-    group_threshold_minus1 = share.group_threshold - 1
-    group_count_minus1 = share.group_count - 1
-    member_threshold_minus1 = share.member_threshold - 1
+  def encode(%__MODULE__{
+        identifier: identifier,
+        extendable: extendable,
+        iteration_exponent: iteration_exponent,
+        group_index: group_index,
+        group_threshold: group_threshold,
+        group_count: group_count,
+        member_index: member_index,
+        member_threshold: member_threshold,
+        share_value: share_value
+      })
+      when identifier in 0..0x7FFF and is_boolean(extendable) and
+             iteration_exponent in 0..15 and group_index in 0..15 and
+             group_threshold in 1..16 and group_count in 1..16 and
+             member_index in 0..15 and member_threshold in 1..16 and
+             is_binary(share_value) and byte_size(share_value) >= 16 and
+             rem(byte_size(share_value), 2) == 0 do
+    pad_bits = rem(@radix_bits - rem(bit_size(share_value), @radix_bits), @radix_bits)
+    ext_bit = if extendable, do: 1, else: 0
+    group_threshold_minus1 = group_threshold - 1
+    group_count_minus1 = group_count - 1
+    member_threshold_minus1 = member_threshold - 1
 
     data_bits =
-      <<share.identifier::15, ext_bit::1, share.iteration_exponent::4, share.group_index::4,
-        group_threshold_minus1::4, group_count_minus1::4, share.member_index::4,
-        member_threshold_minus1::4, 0::size(pad_bits), share.share_value::binary>>
+      <<identifier::15, ext_bit::1, iteration_exponent::4, group_index::4,
+        group_threshold_minus1::4, group_count_minus1::4, member_index::4,
+        member_threshold_minus1::4, 0::size(pad_bits), share_value::binary>>
 
     data_words = for <<idx::10 <- data_bits>>, do: idx
-    words = data_words ++ Encoding.rs1024_create_checksum(data_words, share.extendable)
+    words = data_words ++ Encoding.rs1024_create_checksum(data_words, extendable)
 
     words
     |> Encoding.indices_to_words()

--- a/lib/slip39/share.ex
+++ b/lib/slip39/share.ex
@@ -115,8 +115,12 @@ defmodule Bitcoinex.SLIP39.Share do
     pad_bits = rem(value_words * @radix_bits, 16)
 
     if pad_bits > 8 do
-      # Rules out e.g. 21-word mnemonics, where rem(140, 16) == 12.
-      {:error, :invalid_padding}
+      # Rules out e.g. 21-word mnemonics, where rem(140, 16) == 12. Such a
+      # word count implies a share value that is not a whole number of even
+      # bytes, i.e. it can only be produced by a master secret of invalid
+      # length (official vector 40, "invalid master secret length", is the
+      # 21-word encoding of a 17-byte secret).
+      {:error, :invalid_secret_length}
     else
       # pad_bits <= 8 guarantees the trailing share value is a whole
       # number of bytes, so this match cannot fail.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bitcoinex.MixProject do
   def project do
     [
       app: :bitcoinex,
-      version: "0.1.8",
+      version: "0.2.0",
       elixir: "~> 1.11",
       package: package(),
       start_permanent: Mix.env() == :prod,

--- a/test/slip39/encoding_test.exs
+++ b/test/slip39/encoding_test.exs
@@ -1,0 +1,97 @@
+defmodule Bitcoinex.SLIP39.EncodingTest do
+  use ExUnit.Case
+  use ExUnitProperties
+  doctest Bitcoinex.SLIP39.Encoding
+
+  alias Bitcoinex.SLIP39.Encoding
+
+  describe "rs1024_polymod/1" do
+    test "matches the SLIP-39 reference implementation on fixed word arrays" do
+      # Expected values computed with the reference polymod (trezor
+      # python-shamir-mnemonic rs1024_polymod) over the same inputs.
+      assert Encoding.rs1024_polymod(Enum.to_list(0..9)) == 488_197_068
+      assert Encoding.rs1024_polymod(:binary.bin_to_list("shamir")) == 608_866_019
+    end
+  end
+
+  describe "rs1024_create_checksum/2 and rs1024_verify_checksum/2" do
+    test "create then verify round-trips for ext in {true, false}" do
+      data = [5, 470, 8, 1023, 0, 512, 33, 777, 90, 101, 202, 303, 404]
+
+      for ext <- [true, false] do
+        checksum = Encoding.rs1024_create_checksum(data, ext)
+
+        assert length(checksum) == 3
+        assert Enum.all?(checksum, &(&1 in 0..1023))
+        assert Encoding.rs1024_verify_checksum(data ++ checksum, ext)
+      end
+    end
+
+    test "checksums differ between customization strings" do
+      data = [5, 470, 8, 1023, 0, 512, 33, 777, 90, 101, 202, 303, 404]
+
+      checksum_orig = Encoding.rs1024_create_checksum(data, false)
+      checksum_ext = Encoding.rs1024_create_checksum(data, true)
+
+      assert checksum_orig != checksum_ext
+      refute Encoding.rs1024_verify_checksum(data ++ checksum_orig, true)
+      refute Encoding.rs1024_verify_checksum(data ++ checksum_ext, false)
+    end
+
+    test "verify fails when any 1, 2, or 3 words are mutated" do
+      data = [5, 470, 8, 1023, 0, 512, 33, 777, 90, 101, 202, 303, 404]
+
+      for ext <- [true, false] do
+        words = data ++ Encoding.rs1024_create_checksum(data, ext)
+        last = length(words) - 1
+
+        # Every single-word mutation is detected, at every position.
+        for pos <- 0..last do
+          mutated = List.update_at(words, pos, &Bitwise.bxor(&1, 1))
+          refute Encoding.rs1024_verify_checksum(mutated, ext)
+        end
+
+        # Sampled 2- and 3-word mutations are detected.
+        two_word_mutations = for i <- 0..last, j <- 0..last, i < j, do: [i, j]
+
+        three_word_mutations =
+          for i <- 0..last, j <- 0..last, k <- 0..last, i < j and j < k, do: [i, j, k]
+
+        for positions <- two_word_mutations ++ three_word_mutations do
+          mutated =
+            Enum.reduce(positions, words, fn pos, acc ->
+              List.update_at(acc, pos, &Bitwise.bxor(&1, 3))
+            end)
+
+          refute Encoding.rs1024_verify_checksum(mutated, ext)
+        end
+      end
+    end
+  end
+
+  describe "indices_to_words/1 and words_to_indices/1" do
+    test "round-trips all 1024 indices" do
+      indices = Enum.to_list(0..1023)
+      words = Encoding.indices_to_words(indices)
+
+      assert {:ok, indices} == Encoding.words_to_indices(words)
+    end
+
+    test "unknown word returns {:error, :word_not_in_list}" do
+      assert Encoding.words_to_indices(["academic", "notaword"]) ==
+               {:error, :word_not_in_list}
+
+      assert Encoding.words_to_indices(["ACADEMIC"]) == {:error, :word_not_in_list}
+    end
+  end
+
+  describe "word list" do
+    test "has exactly 1024 unique entries, all of length 4-8" do
+      words = Encoding.indices_to_words(Enum.to_list(0..1023))
+
+      assert length(words) == 1024
+      assert length(Enum.uniq(words)) == 1024
+      assert Enum.all?(words, &(String.length(&1) in 4..8))
+    end
+  end
+end

--- a/test/slip39/share_test.exs
+++ b/test/slip39/share_test.exs
@@ -140,14 +140,15 @@ defmodule Bitcoinex.SLIP39.ShareTest do
       assert Share.decode(vector_mnemonic(2)) == {:error, :invalid_padding}
     end
 
-    test "21-word mnemonic returns {:error, :invalid_padding}" do
+    test "21-word mnemonic returns {:error, :invalid_secret_length}" do
       # rem((21 - 7) * 10, 16) == 12 > 8, so 21-word mnemonics are invalid
-      # even with a correct checksum.
+      # even with a correct checksum: they can only encode a master secret
+      # of invalid (odd) length. Matches official vector 40.
       data = List.duplicate(0, 18)
       indices = data ++ Encoding.rs1024_create_checksum(data, false)
       mnemonic = indices |> Encoding.indices_to_words() |> Enum.join(" ")
 
-      assert Share.decode(mnemonic) == {:error, :invalid_padding}
+      assert Share.decode(mnemonic) == {:error, :invalid_secret_length}
     end
 
     test "vector 39 (insufficient length, 19 words) returns {:error, :invalid_mnemonic_length}" do

--- a/test/slip39/share_test.exs
+++ b/test/slip39/share_test.exs
@@ -222,6 +222,67 @@ defmodule Bitcoinex.SLIP39.ShareTest do
       share_256 = %Share{base | share_value: :binary.copy(<<0>>, 32)}
       assert share_256 |> Share.encode() |> String.split() |> length() == 33
     end
+
+    test "20-byte (160-bit) share value round-trips with zero padding (23 words)" do
+      # rem((23 - 7) * 10, 16) == 0, so this exercises the pad_bits == 0
+      # branch (a zero-width padding match) that the official 128-/256-bit
+      # vectors never hit.
+      share = %Share{
+        identifier: 0x1234,
+        extendable: false,
+        iteration_exponent: 3,
+        group_index: 1,
+        group_threshold: 2,
+        group_count: 3,
+        member_index: 4,
+        member_threshold: 2,
+        share_value: :binary.copy(<<0xAB>>, 20)
+      }
+
+      mnemonic = Share.encode(share)
+      assert length(String.split(mnemonic)) == 23
+      assert Share.decode(mnemonic) == {:ok, share}
+    end
+  end
+
+  describe "encode/1 guard" do
+    setup do
+      valid = %Share{
+        identifier: 1,
+        extendable: false,
+        iteration_exponent: 0,
+        group_index: 0,
+        group_threshold: 1,
+        group_count: 1,
+        member_index: 0,
+        member_threshold: 1,
+        share_value: :binary.copy(<<0>>, 16)
+      }
+
+      %{valid: valid}
+    end
+
+    test "accepts a well-formed struct", %{valid: valid} do
+      assert is_binary(Share.encode(valid))
+    end
+
+    test "raises on an out-of-range field", %{valid: valid} do
+      assert_raise FunctionClauseError, fn -> Share.encode(%Share{valid | identifier: 0x8000}) end
+      assert_raise FunctionClauseError, fn -> Share.encode(%Share{valid | group_threshold: 0}) end
+      assert_raise FunctionClauseError, fn -> Share.encode(%Share{valid | member_index: 16}) end
+    end
+
+    test "raises on a share_value that is not a SLIP-39-valid length", %{valid: valid} do
+      # too short (< 128 bits)
+      assert_raise FunctionClauseError, fn ->
+        Share.encode(%Share{valid | share_value: :binary.copy(<<0>>, 8)})
+      end
+
+      # odd byte count (not a multiple of 16 bits) — would not round-trip
+      assert_raise FunctionClauseError, fn ->
+        Share.encode(%Share{valid | share_value: :binary.copy(<<0>>, 17)})
+      end
+    end
   end
 
   defp share_generator do
@@ -234,7 +295,7 @@ defmodule Bitcoinex.SLIP39.ShareTest do
           group_threshold <- integer(1..group_count),
           member_index <- integer(0..15),
           member_threshold <- integer(1..16),
-          value_length <- member_of([16, 32]),
+          value_length <- member_of([16, 20, 32]),
           share_value <- binary(length: value_length)
         ) do
       %Share{

--- a/test/slip39/share_test.exs
+++ b/test/slip39/share_test.exs
@@ -34,6 +34,14 @@ defmodule Bitcoinex.SLIP39.ShareTest do
              }
     end
 
+    test "vector 42: valid extendable mnemonic without sharing (128 bits)" do
+      # pins the extendable-flag wire path with a named assertion
+      assert {:ok, share} = Share.decode(vector_mnemonic(41))
+      assert share.extendable == true
+      assert byte_size(share.share_value) == 16
+      assert Share.encode(share) == vector_mnemonic(41)
+    end
+
     test "vector 4: basic sharing 2-of-3 (128 bits)" do
       assert {:ok, share} = Share.decode(vector_mnemonic(3))
 
@@ -277,6 +285,22 @@ defmodule Bitcoinex.SLIP39.ShareTest do
 
         mutated = mutated_indices |> Encoding.indices_to_words() |> Enum.join(" ")
         assert {:error, _reason} = Share.decode(mutated)
+      end
+    end
+
+    property "decode never raises on arbitrary strings" do
+      check all(input <- StreamData.string([0x0..0xD7FF, 0xE000..0x10FFFF], max_length: 300)) do
+        assert match?({:ok, _}, Share.decode(input)) or
+                 match?({:error, _}, Share.decode(input))
+      end
+    end
+
+    property "decode never raises on random valid-word sequences" do
+      check all(indices <- list_of(integer(0..1023), min_length: 0, max_length: 40)) do
+        mnemonic = indices |> Encoding.indices_to_words() |> Enum.join(" ")
+
+        assert match?({:ok, _}, Share.decode(mnemonic)) or
+                 match?({:error, _}, Share.decode(mnemonic))
       end
     end
   end

--- a/test/slip39/share_test.exs
+++ b/test/slip39/share_test.exs
@@ -1,0 +1,283 @@
+defmodule Bitcoinex.SLIP39.ShareTest do
+  use ExUnit.Case
+  use ExUnitProperties
+  doctest Bitcoinex.SLIP39.Share
+
+  alias Bitcoinex.SLIP39.Encoding
+  alias Bitcoinex.SLIP39.Share
+  alias Bitcoinex.Utils
+
+  # Official trezor/python-shamir-mnemonic vectors:
+  # [description, mnemonics, ms_hex, xprv] per entry.
+  @vectors_path Path.join(__DIR__, "../data/slip39_vectors.json")
+  @vectors JSON.decode!(File.read!(@vectors_path))
+
+  defp vector_mnemonic(index) do
+    [_description, [mnemonic | _], _ms, _xprv] = Enum.at(@vectors, index)
+    mnemonic
+  end
+
+  describe "decode/1 official vectors" do
+    test "vector 1: valid mnemonic without sharing (128 bits, 20 words)" do
+      assert {:ok, share} = Share.decode(vector_mnemonic(0))
+
+      assert share == %Share{
+               identifier: 7945,
+               extendable: false,
+               iteration_exponent: 0,
+               group_index: 0,
+               group_threshold: 1,
+               group_count: 1,
+               member_index: 0,
+               member_threshold: 1,
+               share_value: Base.decode16!("11bc609d21747c49ba78c0701293e417", case: :lower)
+             }
+    end
+
+    test "vector 4: basic sharing 2-of-3 (128 bits)" do
+      assert {:ok, share} = Share.decode(vector_mnemonic(3))
+
+      assert share == %Share{
+               identifier: 25_653,
+               extendable: false,
+               iteration_exponent: 2,
+               group_index: 0,
+               group_threshold: 1,
+               group_count: 1,
+               member_index: 2,
+               member_threshold: 2,
+               share_value: Base.decode16!("08fb14b66e692e25dfe2edf53289ed62", case: :lower)
+             }
+    end
+
+    test "vector 17: threshold number of groups and members (128 bits)" do
+      assert {:ok, share} = Share.decode(vector_mnemonic(16))
+
+      assert share == %Share{
+               identifier: 9497,
+               extendable: false,
+               iteration_exponent: 0,
+               group_index: 3,
+               group_threshold: 2,
+               group_count: 4,
+               member_index: 0,
+               member_threshold: 2,
+               share_value: Base.decode16!("44e95c567b0b73d470f78e2cc4f206ee", case: :lower)
+             }
+    end
+
+    test "vector 20: valid mnemonic without sharing (256 bits, 33 words)" do
+      mnemonic = vector_mnemonic(19)
+      assert length(String.split(mnemonic)) == 33
+
+      assert {:ok, share} = Share.decode(mnemonic)
+
+      assert share == %Share{
+               identifier: 29_172,
+               extendable: false,
+               iteration_exponent: 0,
+               group_index: 0,
+               group_threshold: 1,
+               group_count: 1,
+               member_index: 0,
+               member_threshold: 1,
+               share_value:
+                 Base.decode16!(
+                   "d772fee46424e100bec16d165f1fcc346d1e8d909da580f9f9f04ea5c788d212",
+                   case: :lower
+                 )
+             }
+
+      assert byte_size(share.share_value) == 32
+    end
+
+    test "encode/1 round-trips every decodable mnemonic across all 45 vectors" do
+      assert length(@vectors) == 45
+
+      decoded_count =
+        for [_description, mnemonics, _ms, _xprv] <- @vectors,
+            mnemonic <- mnemonics,
+            reduce: 0 do
+          acc ->
+            case Share.decode(mnemonic) do
+              {:ok, share} ->
+                assert Share.encode(share) == mnemonic
+                acc + 1
+
+              {:error, _reason} ->
+                acc
+            end
+        end
+
+      # Sanity: the valid vectors alone contribute plenty of decodable shares.
+      assert decoded_count > 45
+    end
+  end
+
+  describe "decode/1 errors" do
+    test "vector 2 (invalid checksum) returns {:error, :invalid_checksum}" do
+      assert Share.decode(vector_mnemonic(1)) == {:error, :invalid_checksum}
+    end
+
+    test "mutated checksum word returns {:error, :invalid_checksum}" do
+      mnemonic = vector_mnemonic(0)
+      words = String.split(mnemonic)
+      mutated = words |> List.replace_at(19, "academic") |> Enum.join(" ")
+
+      assert mutated != mnemonic
+      assert Share.decode(mutated) == {:error, :invalid_checksum}
+    end
+
+    test "vector 3 (invalid padding) returns {:error, :invalid_padding}" do
+      assert Share.decode(vector_mnemonic(2)) == {:error, :invalid_padding}
+    end
+
+    test "21-word mnemonic returns {:error, :invalid_padding}" do
+      # rem((21 - 7) * 10, 16) == 12 > 8, so 21-word mnemonics are invalid
+      # even with a correct checksum.
+      data = List.duplicate(0, 18)
+      indices = data ++ Encoding.rs1024_create_checksum(data, false)
+      mnemonic = indices |> Encoding.indices_to_words() |> Enum.join(" ")
+
+      assert Share.decode(mnemonic) == {:error, :invalid_padding}
+    end
+
+    test "vector 39 (insufficient length, 19 words) returns {:error, :invalid_mnemonic_length}" do
+      mnemonic = vector_mnemonic(38)
+
+      assert length(String.split(mnemonic)) == 19
+      assert Share.decode(mnemonic) == {:error, :invalid_mnemonic_length}
+    end
+
+    test "short mnemonics return {:error, :invalid_mnemonic_length}" do
+      assert Share.decode("academic academic academic") == {:error, :invalid_mnemonic_length}
+    end
+
+    test "vectors 10 and 29 (group threshold > group count) return {:error, :invalid_group_threshold}" do
+      assert Share.decode(vector_mnemonic(9)) == {:error, :invalid_group_threshold}
+      assert Share.decode(vector_mnemonic(28)) == {:error, :invalid_group_threshold}
+    end
+
+    test "word not in list returns {:error, :word_not_in_list}" do
+      mnemonic = vector_mnemonic(0)
+      mutated = mnemonic |> String.split() |> List.replace_at(0, "bitcoin") |> Enum.join(" ")
+
+      assert Share.decode(mutated) == {:error, :word_not_in_list}
+    end
+  end
+
+  describe "wire format" do
+    test "thresholds and counts are stored minus 1 on the wire" do
+      share = %Share{
+        identifier: 0x1234,
+        extendable: true,
+        iteration_exponent: 5,
+        group_index: 7,
+        group_threshold: 2,
+        group_count: 3,
+        member_index: 9,
+        member_threshold: 4,
+        share_value: :binary.copy(<<0xAB>>, 16)
+      }
+
+      {:ok, indices} = share |> Share.encode() |> String.split() |> Encoding.words_to_indices()
+
+      <<identifier::15, ext_bit::1, iteration_exponent::4, group_index::4,
+        group_threshold_wire::4, group_count_wire::4, member_index::4, member_threshold_wire::4,
+        _rest::bitstring>> = Utils.int_list_to_bits(indices, 10)
+
+      assert identifier == 0x1234
+      assert ext_bit == 1
+      assert iteration_exponent == 5
+      assert group_index == 7
+      assert group_threshold_wire == 1
+      assert group_count_wire == 2
+      assert member_index == 9
+      assert member_threshold_wire == 3
+    end
+
+    test "16-byte share value encodes to 20 words, 32-byte to 33 words" do
+      base = %Share{
+        identifier: 1,
+        extendable: false,
+        iteration_exponent: 0,
+        group_index: 0,
+        group_threshold: 1,
+        group_count: 1,
+        member_index: 0,
+        member_threshold: 1,
+        share_value: :binary.copy(<<0>>, 16)
+      }
+
+      assert base |> Share.encode() |> String.split() |> length() == 20
+
+      share_256 = %Share{base | share_value: :binary.copy(<<0>>, 32)}
+      assert share_256 |> Share.encode() |> String.split() |> length() == 33
+    end
+  end
+
+  defp share_generator do
+    gen all(
+          identifier <- integer(0..0x7FFF),
+          extendable <- boolean(),
+          iteration_exponent <- integer(0..15),
+          group_index <- integer(0..15),
+          group_count <- integer(1..16),
+          group_threshold <- integer(1..group_count),
+          member_index <- integer(0..15),
+          member_threshold <- integer(1..16),
+          value_length <- member_of([16, 32]),
+          share_value <- binary(length: value_length)
+        ) do
+      %Share{
+        identifier: identifier,
+        extendable: extendable,
+        iteration_exponent: iteration_exponent,
+        group_index: group_index,
+        group_threshold: group_threshold,
+        group_count: group_count,
+        member_index: member_index,
+        member_threshold: member_threshold,
+        share_value: share_value
+      }
+    end
+  end
+
+  describe "properties" do
+    property "decode(encode(share)) round-trips any valid share" do
+      check all(share <- share_generator()) do
+        assert share |> Share.encode() |> Share.decode() == {:ok, share}
+      end
+    end
+
+    property "mutating 1-3 words of a valid share always fails to decode" do
+      check all(
+              share <- share_generator(),
+              offsets <- list_of(integer(1..1023), min_length: 1, max_length: 3),
+              position_picks <- list_of(integer(0..10_000), length: 3)
+            ) do
+        mnemonic = Share.encode(share)
+        {:ok, indices} = mnemonic |> String.split() |> Encoding.words_to_indices()
+        word_count = length(indices)
+
+        positions =
+          position_picks
+          |> Enum.map(&rem(&1, word_count))
+          |> Enum.uniq()
+          |> Enum.take(length(offsets))
+
+        mutated_indices =
+          positions
+          |> Enum.zip(offsets)
+          |> Enum.reduce(indices, fn {position, offset}, acc ->
+            List.update_at(acc, position, &rem(&1 + offset, 1024))
+          end)
+
+        assert mutated_indices != indices
+
+        mutated = mutated_indices |> Encoding.indices_to_words() |> Enum.join(" ")
+        assert {:error, _reason} = Share.decode(mutated)
+      end
+    end
+  end
+end

--- a/test/slip39_test.exs
+++ b/test/slip39_test.exs
@@ -257,6 +257,37 @@ defmodule Bitcoinex.SLIP39Test do
       assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: <<7>>) ==
                {:error, :invalid_passphrase}
     end
+
+    test "out-of-range identifier returns {:error, :invalid_identifier}" do
+      # the wire format truncates identifiers to 15 bits: an unvalidated
+      # identifier of 40_000 would encode as 7232 while the Feistel salt
+      # used 40_000, so recombination would silently yield a wrong secret
+      for bad <- [40_000, 0x8000, -1, :zero, "0"] do
+        assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, identifier: bad) ==
+                 {:error, :invalid_identifier}
+      end
+    end
+
+    test "identifier boundary values are accepted and round-trip" do
+      for identifier <- [0, 0x7FFF] do
+        assert {:ok, [mnemonics]} =
+                 SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16,
+                   identifier: identifier,
+                   rng: make_rng(41)
+                 )
+
+        assert SLIP39.combine_mnemonics(Enum.take(mnemonics, 2)) == {:ok, @secret_16}
+      end
+    end
+
+    test "out-of-range iteration exponent returns {:error, :invalid_iteration_exponent}" do
+      # the wire format truncates the exponent to 4 bits: e = 16 would
+      # encode as 0 while encryption used 10_000 <<< 16 iterations
+      for bad <- [16, -1, 1.0] do
+        assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, iteration_exponent: bad) ==
+                 {:error, :invalid_iteration_exponent}
+      end
+    end
   end
 
   describe "combine_mnemonics/2 validation" do

--- a/test/slip39_test.exs
+++ b/test/slip39_test.exs
@@ -1,0 +1,362 @@
+defmodule Bitcoinex.SLIP39Test do
+  use ExUnit.Case
+  use ExUnitProperties
+
+  alias Bitcoinex.ExtendedKey
+  alias Bitcoinex.SLIP39
+  alias Bitcoinex.SLIP39.Share
+
+  doctest Bitcoinex.SLIP39
+
+  # Official SLIP-39 test vectors, byte-identical to
+  # https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/vectors.json
+  # (sha256: 13ebecebdd869dd2bc2cdf69e7ce3a158cf106cac76c39d17682b1c6cdabbdc4).
+  # Each vector is [description, mnemonics, master_secret_hex, xprv]; the 15
+  # valid vectors have a non-empty master_secret_hex and use passphrase
+  # "TREZOR"; the 30 invalid vectors have an empty master_secret_hex.
+  @vectors_path Path.join(__DIR__, "data/slip39_vectors.json")
+  @external_resource @vectors_path
+  @vectors @vectors_path |> File.read!() |> JSON.decode!()
+
+  @secret_16 Base.decode16!("4142434445464748494a4b4c4d4e4f50", case: :lower)
+  @secret_32 Base.decode16!(
+               "989baf9dcaad5b10a5eec78afcaf0a1cc762c9e3d7cadef8aac343109fd90c69",
+               case: :lower
+             )
+
+  # Deterministic rng stub: a counter-keyed SHA-256 stream. Every call
+  # produces different (but reproducible) bytes; no CSPRNG is used in tests.
+  defp make_rng(seed) do
+    counter = :atomics.new(1, signed: false)
+
+    fn byte_count ->
+      call_index = :atomics.add_get(counter, 1, 1)
+      expand_bytes(<<seed::unsigned-64, call_index::unsigned-64>>, byte_count, <<>>)
+    end
+  end
+
+  defp expand_bytes(_key, byte_count, acc) when byte_size(acc) >= byte_count,
+    do: binary_part(acc, 0, byte_count)
+
+  defp expand_bytes(key, byte_count, acc) do
+    block = :crypto.hash(:sha256, [key, <<byte_size(acc)::unsigned-32>>])
+    expand_bytes(key, byte_count, acc <> block)
+  end
+
+  defp combinations(_list, 0), do: [[]]
+  defp combinations([], _k), do: []
+
+  defp combinations([head | tail], k) do
+    for(combo <- combinations(tail, k - 1), do: [head | combo]) ++ combinations(tail, k)
+  end
+
+  # Maps each invalid official vector's description to the specific error
+  # atom combine_mnemonics/2 must return for it.
+  defp expected_error(description) do
+    cond do
+      description =~ "invalid checksum" -> :invalid_checksum
+      description =~ "invalid padding" -> :invalid_padding
+      description =~ "greater group threshold than group counts" -> :invalid_group_threshold
+      description =~ "different identifiers" -> :mismatching_shares
+      description =~ "different iteration exponents" -> :mismatching_shares
+      description =~ "mismatching group thresholds" -> :mismatching_shares
+      description =~ "mismatching group counts" -> :mismatching_shares
+      description =~ "mismatching member thresholds" -> :mismatching_shares
+      description =~ "duplicate member indices" -> :duplicate_member_index
+      description =~ "invalid digest" -> :invalid_digest
+      description =~ "Insufficient number of groups" -> :insufficient_groups
+      description =~ "insufficient number of members" -> :insufficient_member_shares
+      description =~ "Basic sharing 2-of-3" -> :insufficient_member_shares
+      description =~ "insufficient length" -> :invalid_mnemonic_length
+      description =~ "invalid master secret length" -> :invalid_secret_length
+    end
+  end
+
+  describe "official vectors" do
+    test "vector file contains 15 valid and 30 invalid vectors" do
+      assert length(@vectors) == 45
+      assert Enum.count(@vectors, fn [_d, _m, ms_hex, _x] -> ms_hex != "" end) == 15
+      assert Enum.count(@vectors, fn [_d, _m, ms_hex, _x] -> ms_hex == "" end) == 30
+    end
+
+    test "all valid vectors recover the master secret and derive the xprv" do
+      for [description, mnemonics, ms_hex, xprv] <- @vectors, ms_hex != "" do
+        ms = Base.decode16!(ms_hex, case: :lower)
+
+        assert SLIP39.combine_mnemonics(mnemonics, "TREZOR") == {:ok, ms},
+               "vector failed: #{description}"
+
+        assert {:ok, xkey} = ExtendedKey.seed_to_master_private_key(ms)
+
+        assert ExtendedKey.display_extended_key(xkey) == xprv,
+               "xprv mismatch for vector: #{description}"
+      end
+    end
+
+    test "all invalid vectors return the specific error atom for their description" do
+      for [description, mnemonics, ms_hex, _xprv] <- @vectors, ms_hex == "" do
+        assert SLIP39.combine_mnemonics(mnemonics, "TREZOR") ==
+                 {:error, expected_error(description)},
+               "vector failed: #{description}"
+      end
+    end
+  end
+
+  describe "generate_mnemonics/4 + combine_mnemonics/2 round-trips" do
+    test "single group 2-of-3: every 2-subset recovers the secret" do
+      rng = make_rng(1)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, rng: rng)
+      assert length(shares) == 3
+
+      for subset <- combinations(shares, 2) do
+        assert SLIP39.combine_mnemonics(subset) == {:ok, @secret_16}
+      end
+    end
+
+    test "multi-group 2-of-[(2,3),(3,5),(1,1)]: exact-threshold subsets of any 2 groups" do
+      rng = make_rng(2)
+
+      assert {:ok, [g0, g1, g2]} =
+               SLIP39.generate_mnemonics(2, [{2, 3}, {3, 5}, {1, 1}], @secret_32,
+                 passphrase: "TREZOR",
+                 rng: rng
+               )
+
+      assert length(g0) == 3
+      assert length(g1) == 5
+      assert length(g2) == 1
+
+      # groups 0 + 1
+      assert SLIP39.combine_mnemonics(Enum.take(g0, 2) ++ Enum.take(g1, 3), "TREZOR") ==
+               {:ok, @secret_32}
+
+      # groups 0 + 2, a different member subset of group 0
+      assert SLIP39.combine_mnemonics([Enum.at(g0, 0), Enum.at(g0, 2)] ++ g2, "TREZOR") ==
+               {:ok, @secret_32}
+
+      # groups 1 + 2, a different member subset of group 1
+      assert SLIP39.combine_mnemonics(
+               g2 ++ [Enum.at(g1, 4), Enum.at(g1, 1), Enum.at(g1, 3)],
+               "TREZOR"
+             ) == {:ok, @secret_32}
+    end
+
+    test "16 groups of (1,1) with group threshold 16" do
+      rng = make_rng(3)
+      groups = List.duplicate({1, 1}, 16)
+
+      assert {:ok, group_mnemonics} = SLIP39.generate_mnemonics(16, groups, @secret_16, rng: rng)
+
+      all_shares = List.flatten(group_mnemonics)
+      assert length(all_shares) == 16
+      assert SLIP39.combine_mnemonics(all_shares) == {:ok, @secret_16}
+    end
+
+    test "share order does not matter" do
+      rng = make_rng(4)
+
+      assert {:ok, [g0, g1]} =
+               SLIP39.generate_mnemonics(2, [{2, 3}, {2, 2}], @secret_16, rng: rng)
+
+      subset = Enum.take(g0, 2) ++ g1
+
+      for shuffled <- [Enum.reverse(subset), Enum.shuffle(subset), Enum.shuffle(subset)] do
+        assert SLIP39.combine_mnemonics(shuffled) == {:ok, @secret_16}
+      end
+    end
+
+    test "extendable: true and extendable: false both round-trip" do
+      for extendable <- [true, false] do
+        rng = make_rng(5)
+
+        assert {:ok, [shares]} =
+                 SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16,
+                   extendable: extendable,
+                   rng: rng
+                 )
+
+        assert {:ok, %Share{extendable: ^extendable}} = Share.decode(hd(shares))
+        assert SLIP39.combine_mnemonics(Enum.take(shares, 2)) == {:ok, @secret_16}
+      end
+    end
+
+    test "explicit identifier and iteration exponent are threaded through" do
+      rng = make_rng(6)
+
+      assert {:ok, [shares]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16,
+                 identifier: 12_345,
+                 iteration_exponent: 1,
+                 extendable: false,
+                 rng: rng
+               )
+
+      assert {:ok, %Share{identifier: 12_345, iteration_exponent: 1}} = Share.decode(hd(shares))
+      assert SLIP39.combine_mnemonics(shares) == {:ok, @secret_16}
+    end
+
+    test "wrong passphrase yields a different master secret, not an error" do
+      rng = make_rng(7)
+
+      assert {:ok, [shares]} =
+               SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: "TREZOR", rng: rng)
+
+      subset = Enum.take(shares, 2)
+
+      assert SLIP39.combine_mnemonics(subset, "TREZOR") == {:ok, @secret_16}
+
+      # SLIP-39 plausible deniability: a wrong passphrase silently decrypts
+      # to a different master secret.
+      assert {:ok, wrong_ms} = SLIP39.combine_mnemonics(subset, "NOT TREZOR")
+      assert wrong_ms != @secret_16
+      assert byte_size(wrong_ms) == byte_size(@secret_16)
+    end
+  end
+
+  describe "generate_mnemonics/4 validation" do
+    test "master secret shorter than 16 bytes returns {:error, :invalid_secret_length}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], :binary.copy(<<1>>, 15)) ==
+               {:error, :invalid_secret_length}
+    end
+
+    test "master secret of odd length returns {:error, :invalid_secret_length}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], :binary.copy(<<1>>, 17)) ==
+               {:error, :invalid_secret_length}
+    end
+
+    test "group threshold above the group count returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(3, [{2, 3}, {2, 3}], @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "group threshold of 0 returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(0, [{2, 3}], @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "more than 16 groups returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(1, List.duplicate({1, 1}, 17), @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "member threshold above the member count returns {:error, :invalid_member_threshold}" do
+      assert SLIP39.generate_mnemonics(1, [{3, 2}], @secret_16) ==
+               {:error, :invalid_member_threshold}
+    end
+
+    test "member threshold of 1 with more than 1 share returns {:error, :invalid_member_threshold}" do
+      assert SLIP39.generate_mnemonics(1, [{1, 2}], @secret_16) ==
+               {:error, :invalid_member_threshold}
+    end
+
+    test "non-printable-ASCII passphrase returns {:error, :invalid_passphrase}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: "café") ==
+               {:error, :invalid_passphrase}
+
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: <<7>>) ==
+               {:error, :invalid_passphrase}
+    end
+  end
+
+  describe "combine_mnemonics/2 validation" do
+    test "empty mnemonic list returns {:error, :empty_mnemonic_set}" do
+      assert SLIP39.combine_mnemonics([]) == {:error, :empty_mnemonic_set}
+    end
+
+    test "non-printable-ASCII passphrase returns {:error, :invalid_passphrase}" do
+      assert SLIP39.combine_mnemonics(["any mnemonic"], "café") == {:error, :invalid_passphrase}
+      assert SLIP39.combine_mnemonics(["any mnemonic"], <<7>>) == {:error, :invalid_passphrase}
+    end
+
+    test "more groups than the group threshold returns {:error, :too_many_groups}" do
+      rng = make_rng(8)
+
+      assert {:ok, groups} =
+               SLIP39.generate_mnemonics(2, [{1, 1}, {1, 1}, {1, 1}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(List.flatten(groups)) == {:error, :too_many_groups}
+    end
+
+    test "fewer groups than the group threshold returns {:error, :insufficient_groups}" do
+      rng = make_rng(9)
+
+      assert {:ok, [g0, _g1]} =
+               SLIP39.generate_mnemonics(2, [{2, 2}, {2, 2}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(g0) == {:error, :insufficient_groups}
+    end
+
+    test "more member shares than the member threshold returns {:error, :too_many_member_shares}" do
+      rng = make_rng(10)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, rng: rng)
+      assert SLIP39.combine_mnemonics(shares) == {:error, :too_many_member_shares}
+    end
+
+    test "fewer member shares than the member threshold returns {:error, :insufficient_member_shares}" do
+      rng = make_rng(11)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{3, 5}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(Enum.take(shares, 2)) ==
+               {:error, :insufficient_member_shares}
+    end
+
+    test "shares from different share sets return {:error, :mismatching_shares}" do
+      assert {:ok, [[share_a | _]]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16, rng: make_rng(12))
+
+      assert {:ok, [[_, share_b]]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16, rng: make_rng(13))
+
+      assert SLIP39.combine_mnemonics([share_a, share_b]) == {:error, :mismatching_shares}
+    end
+  end
+
+  # 1 <= t <= n <= 4, excluding the forbidden t == 1 && n > 1 case.
+  defp group_spec_generator do
+    gen all(
+          member_threshold <- integer(1..4),
+          member_count <-
+            if(member_threshold == 1,
+              do: constant(1),
+              else: integer(member_threshold..4)
+            )
+        ) do
+      {member_threshold, member_count}
+    end
+  end
+
+  describe "properties" do
+    property "full-stack round-trip: exact-threshold shuffled subsets recover the secret" do
+      check all(
+              master_secret <- one_of([binary(length: 16), binary(length: 32)]),
+              groups <- list_of(group_spec_generator(), min_length: 1, max_length: 4),
+              group_threshold <- integer(1..length(groups)),
+              seed <- integer(0..1_000_000),
+              max_runs: 25
+            ) do
+        rng = make_rng(seed)
+
+        assert {:ok, group_mnemonics} =
+                 SLIP39.generate_mnemonics(group_threshold, groups, master_secret,
+                   iteration_exponent: 0,
+                   rng: rng
+                 )
+
+        subset =
+          group_mnemonics
+          |> Enum.zip(groups)
+          |> Enum.shuffle()
+          |> Enum.take(group_threshold)
+          |> Enum.flat_map(fn {mnemonics, {member_threshold, _member_count}} ->
+            mnemonics |> Enum.shuffle() |> Enum.take(member_threshold)
+          end)
+          |> Enum.shuffle()
+
+        assert SLIP39.combine_mnemonics(subset) == {:ok, master_secret}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stack: S0 → S1 → S2 → S3 → S4 → **S5** → S6 (spec §3.7, §3.8)

- `Bitcoinex.SLIP39.Encoding`: RS1024 polymod (bech32-polymod style) with "shamir"/"shamir_extendable" customization, checksum create/verify, word↔index mapping
- `Bitcoinex.SLIP39.Share`: bit-exact wire codec; decode validates length, RS1024 (ext bit peeked pre-verify), ≤8-bit zero padding, GT≤G; encode is total on valid structs
- Official-vector coverage: full metadata asserts on 4 vectors (incl. 33-word/256-bit), byte-identical encode∘decode round-trip over every mnemonic in all 45 vectors, specific error atoms for invalid-checksum/padding/length/group-threshold vectors; RS1024 1–3-word mutation guarantee property

🤖 Generated with [Claude Code](https://claude.com/claude-code)