### PR TITLE
S6: SLIP-39 two-level share orchestration (generate/combine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - BIP-39 mnemonic support (`Bitcoinex.BIP39`): entropy-to-mnemonic encoding and decoding with checksum validation, NFKD-normalized seed derivation via PBKDF2-HMAC-SHA512, and master extended private key derivation.
+- SLIP-39 Shamir's Secret-Sharing mnemonic support (`Bitcoinex.SLIP39`): two-level (group/member) secret splitting via `generate_mnemonics/4` and recovery via `combine_mnemonics/2`, with passphrase encryption (four-round Feistel over PBKDF2-HMAC-SHA256), GF(256) Shamir sharing with digest verification, RS1024 checksums, and the extendable share-set flag. Verified against all 45 official SLIP-0039 test vectors.
 
 ## [0.1.8] - 2024-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-01
 ### Added
 - BIP-39 mnemonic support (`Bitcoinex.BIP39`): entropy-to-mnemonic encoding and decoding with checksum validation, NFKD-normalized seed derivation via PBKDF2-HMAC-SHA512, and master extended private key derivation.
 - SLIP-39 Shamir's Secret-Sharing mnemonic support (`Bitcoinex.SLIP39`): two-level (group/member) secret splitting via `generate_mnemonics/4` and recovery via `combine_mnemonics/2`, with passphrase encryption (four-round Feistel over PBKDF2-HMAC-SHA256), GF(256) Shamir sharing with digest verification, RS1024 checksums, and the extendable share-set flag. Verified against all 45 official SLIP-0039 test vectors.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Documentation is available on [hexdocs.pm](https://hexdocs.pm/bitcoinex/api-refe
 * Support for standard on-chain scripts (P2PKH..P2WPKH) and Bolt#11 Lightning Invoices.
 * Transaction serialization.
 * Basic PSBT (BIP174) parsing.
+* BIP39 mnemonic seed phrases: entropy encoding/decoding and seed derivation.
+* SLIP39 Shamir's Secret-Sharing mnemonics: split and recover master secrets.
 
 ## Usage
 

--- a/docs/specs/slip39-bip39-primitives.md
+++ b/docs/specs/slip39-bip39-primitives.md
@@ -224,7 +224,7 @@ Note thresholds/counts are stored **1-based** in the struct; the wire format sto
 ```
 
 **`generate_mnemonics/4`.**
-1. Validate: `master_secret` byte length even and `≥ 16` (`:invalid_secret_length`); `1 ≤ group_threshold ≤ length(groups) ≤ 16` (`:invalid_group_threshold`); each `{t,n}` with `1 ≤ t ≤ n ≤ 16`, and **not** (`t == 1 and n > 1`) (`:invalid_member_threshold`); passphrase contains only printable ASCII (code points 32–126, per SLIP-39 — `String.to_charlist |> Enum.all?(&(&1 in 32..126))`) (`:invalid_passphrase`).
+1. Validate: `master_secret` byte length even and `≥ 16` (`:invalid_secret_length`); `1 ≤ group_threshold ≤ length(groups) ≤ 16` (`:invalid_group_threshold`); each `{t,n}` with `1 ≤ t ≤ n ≤ 16`, and **not** (`t == 1 and n > 1`) (`:invalid_member_threshold`); passphrase contains only printable ASCII (code points 32–126, per SLIP-39 — `String.to_charlist |> Enum.all?(&(&1 in 32..126))`) (`:invalid_passphrase`). Additionally, `identifier` opt must be `nil` or an integer in `0..0x7FFF` (`:invalid_identifier`) and `iteration_exponent` an integer in `0..15` (`:invalid_iteration_exponent`) — the wire format truncates these to 15/4 bits, so unvalidated out-of-range values would encode shares whose recombination silently yields a different master secret.
 2. `identifier` = opt or `:rand`-free draw of 15 bits from `rng` (`<<id::15, _::1>> = rng.(2)`).
 3. `ems = Cipher.encrypt(master_secret, passphrase, e, id, ext)`.
 4. `group_shares = Shamir.split_secret(group_threshold, length(groups), ems, rng)` → `[{group_index, group_value}]`.
@@ -301,7 +301,7 @@ Word lists and checksum logic otherwise stay scheme-specific (RS1024 ≠ bech32 
 - All `@`-constants from §3.3.
 - `@type group_spec`, `generate_mnemonics/4`, `combine_mnemonics/2` (§3.9).
 - private validators (`validate_secret/1`, `validate_groups/2`), grouping/consistency helpers.
-- Error atoms: `:invalid_secret_length`, `:invalid_group_threshold`, `:invalid_member_threshold`, `:invalid_passphrase`, `:mismatching_shares`, `:insufficient_groups`, `:too_many_groups`, `:insufficient_member_shares`, `:too_many_member_shares`, `:duplicate_member_index`, `:empty_mnemonic_set`.
+- Error atoms: `:invalid_secret_length`, `:invalid_group_threshold`, `:invalid_member_threshold`, `:invalid_passphrase`, `:mismatching_shares`, `:insufficient_groups`, `:too_many_groups`, `:insufficient_member_shares`, `:too_many_member_shares`, `:duplicate_member_index`, `:empty_mnemonic_set`, `:invalid_identifier`, `:invalid_iteration_exponent`.
 
 ### `lib/slip39/gf256.ex` — `Bitcoinex.SLIP39.GF256` (new)
 - `@exp_table`, `@log_table` (generated in the module body per §3.4 — not via a same-module `defp`; generator 3, poly `0x11B`).

--- a/lib/slip39.ex
+++ b/lib/slip39.ex
@@ -68,7 +68,11 @@ defmodule Bitcoinex.SLIP39 do
   `1 <= group_threshold <= length(groups) <= 16`),
   `:invalid_member_threshold` (each spec requires `1 <= t <= n <= 16` and
   forbids `t == 1` with `n > 1`), `:invalid_passphrase` (printable ASCII,
-  code points 32-126, only).
+  code points 32-126, only), `:invalid_identifier` (integer in `0..0x7FFF`),
+  `:invalid_iteration_exponent` (integer in `0..15`). The identifier and
+  iteration exponent are range-checked because the wire format truncates
+  them to 15 and 4 bits: unvalidated out-of-range values would encode
+  shares whose recombination silently yields a different master secret.
   """
   @spec generate_mnemonics(1..16, [group_spec()], binary(), keyword()) ::
           {:ok, [[String.t()]]} | {:error, atom()}
@@ -81,8 +85,14 @@ defmodule Bitcoinex.SLIP39 do
     with :ok <- validate_secret(master_secret),
          :ok <- validate_group_threshold(group_threshold, length(groups)),
          :ok <- validate_groups(groups),
-         :ok <- validate_passphrase(passphrase) do
-      identifier = Keyword.get(opts, :identifier) || random_identifier(rng)
+         :ok <- validate_passphrase(passphrase),
+         :ok <- validate_identifier(Keyword.get(opts, :identifier)),
+         :ok <- validate_iteration_exponent(iteration_exponent) do
+      identifier =
+        case Keyword.get(opts, :identifier) do
+          nil -> random_identifier(rng)
+          identifier -> identifier
+        end
 
       ems =
         Cipher.encrypt(master_secret, passphrase, iteration_exponent, identifier, extendable)
@@ -192,6 +202,20 @@ defmodule Bitcoinex.SLIP39 do
       {:error, :invalid_passphrase}
     end
   end
+
+  # the wire format truncates the identifier to 15 bits and the iteration
+  # exponent to 4 bits; out-of-range values would encrypt with parameters
+  # that differ from the encoded ones, so recombination would silently
+  # yield a different master secret
+  defp validate_identifier(nil), do: :ok
+
+  defp validate_identifier(identifier) when is_integer(identifier) and identifier in 0..0x7FFF,
+    do: :ok
+
+  defp validate_identifier(_identifier), do: {:error, :invalid_identifier}
+
+  defp validate_iteration_exponent(e) when is_integer(e) and e in 0..15, do: :ok
+  defp validate_iteration_exponent(_e), do: {:error, :invalid_iteration_exponent}
 
   defp validate_non_empty([]), do: {:error, :empty_mnemonic_set}
   defp validate_non_empty(_mnemonics), do: :ok

--- a/lib/slip39.ex
+++ b/lib/slip39.ex
@@ -1,0 +1,262 @@
+defmodule Bitcoinex.SLIP39 do
+  @moduledoc """
+  SLIP-0039: Shamir's Secret-Sharing for Mnemonic Codes.
+
+  Splits a master secret into a two-level hierarchy of mnemonic shares and
+  recombines them. The master secret is first encrypted under a passphrase
+  (`Bitcoinex.SLIP39.Cipher`), then split into group shares, each of which is
+  split into member shares (`Bitcoinex.SLIP39.Shamir`); each member share is
+  encoded as a mnemonic (`Bitcoinex.SLIP39.Share`). Recovering the master
+  secret requires exactly `group_threshold` groups, each contributing exactly
+  its member threshold of shares.
+
+  Note that SLIP-39 offers plausible deniability: combining a valid share set
+  with a wrong passphrase does not fail, it silently yields a different
+  master secret. The caller is responsible for passphrase correctness.
+
+  Elixir binaries are immutable and garbage-collected, so this library cannot
+  guarantee zeroization of secrets or passphrases in memory.
+
+  ## Examples
+
+      iex> rng = fn byte_count -> :binary.copy(<<7>>, byte_count) end
+      iex> master_secret = :binary.copy(<<0xAB>>, 16)
+      iex> {:ok, [[share_a, share_b, _share_c]]} =
+      ...>   Bitcoinex.SLIP39.generate_mnemonics(1, [{2, 3}], master_secret, rng: rng)
+      iex> {:ok, recovered} = Bitcoinex.SLIP39.combine_mnemonics([share_a, share_b])
+      iex> recovered == master_secret
+      true
+  """
+
+  alias Bitcoinex.SLIP39.{Cipher, Shamir, Share}
+
+  @id_length_bits 15
+  @max_share_count 16
+  @min_strength_bits 128
+  @min_strength_bytes div(@min_strength_bits, 8)
+
+  @typedoc """
+  A group specification: `{member_threshold, member_count}`. The group is
+  split into `member_count` shares, any `member_threshold` of which recover
+  the group share.
+  """
+  @type group_spec :: {member_threshold :: 1..16, member_count :: 1..16}
+
+  @doc """
+  generate_mnemonics splits `master_secret` into SLIP-39 mnemonic shares.
+
+  The secret is split into `length(groups)` group shares, any
+  `group_threshold` of which recover it; each group `i` is split into member
+  shares per its `{member_threshold, member_count}` spec. Returns
+  `{:ok, groups_of_mnemonics}` where the i-th element is the list of mnemonic
+  strings for the i-th group spec.
+
+  Options:
+
+  - `:passphrase` (default `""`) — printable-ASCII encryption passphrase.
+  - `:extendable` (default `true`) — whether the share set is extendable
+    (the identifier is then not used as an encryption salt).
+  - `:iteration_exponent` (default `0`) — PBKDF2 cost, `2500 <<< e` per round.
+  - `:rng` (default `&:crypto.strong_rand_bytes/1`) — randomness source,
+    `byte_count -> binary`. Injectable ONLY for deterministic tests;
+    production callers must use a CSPRNG.
+  - `:identifier` (default `nil`) — 15-bit share-set identifier; drawn from
+    `rng` when `nil`.
+
+  Errors: `:invalid_secret_length` (must be at least 16 bytes and of even
+  length), `:invalid_group_threshold` (requires
+  `1 <= group_threshold <= length(groups) <= 16`),
+  `:invalid_member_threshold` (each spec requires `1 <= t <= n <= 16` and
+  forbids `t == 1` with `n > 1`), `:invalid_passphrase` (printable ASCII,
+  code points 32-126, only).
+  """
+  @spec generate_mnemonics(1..16, [group_spec()], binary(), keyword()) ::
+          {:ok, [[String.t()]]} | {:error, atom()}
+  def generate_mnemonics(group_threshold, groups, master_secret, opts \\ []) do
+    passphrase = Keyword.get(opts, :passphrase, "")
+    extendable = Keyword.get(opts, :extendable, true)
+    iteration_exponent = Keyword.get(opts, :iteration_exponent, 0)
+    rng = Keyword.get(opts, :rng, &:crypto.strong_rand_bytes/1)
+
+    with :ok <- validate_secret(master_secret),
+         :ok <- validate_group_threshold(group_threshold, length(groups)),
+         :ok <- validate_groups(groups),
+         :ok <- validate_passphrase(passphrase) do
+      identifier = Keyword.get(opts, :identifier) || random_identifier(rng)
+
+      ems =
+        Cipher.encrypt(master_secret, passphrase, iteration_exponent, identifier, extendable)
+
+      mnemonics =
+        group_threshold
+        |> Shamir.split_secret(length(groups), ems, rng)
+        |> Enum.zip(groups)
+        |> Enum.map(fn {{group_index, group_value}, {member_threshold, member_count}} ->
+          member_threshold
+          |> Shamir.split_secret(member_count, group_value, rng)
+          |> Enum.map(fn {member_index, share_value} ->
+            Share.encode(%Share{
+              identifier: identifier,
+              extendable: extendable,
+              iteration_exponent: iteration_exponent,
+              group_index: group_index,
+              group_threshold: group_threshold,
+              group_count: length(groups),
+              member_index: member_index,
+              member_threshold: member_threshold,
+              share_value: share_value
+            })
+          end)
+        end)
+
+      {:ok, mnemonics}
+    end
+  end
+
+  @doc """
+  combine_mnemonics recovers the master secret from SLIP-39 mnemonics.
+
+  The share set must contain exactly `group_threshold` distinct groups, and
+  each group must contribute exactly its member threshold of shares with
+  distinct member indices.
+
+  A wrong passphrase does not fail: it yields a different master secret
+  (SLIP-39 plausible deniability), so the caller must verify the result.
+
+  Errors: any `Bitcoinex.SLIP39.Share.decode/1` error (propagated as-is),
+  `:invalid_passphrase`, `:empty_mnemonic_set`, `:mismatching_shares`
+  (shares disagree on identifier, extendable flag, iteration exponent, group
+  threshold, group count, share value length, or member threshold within a
+  group), `:insufficient_groups`, `:too_many_groups`,
+  `:insufficient_member_shares`, `:too_many_member_shares`,
+  `:duplicate_member_index`, `:invalid_digest` (recovered share set is
+  inconsistent or corrupted).
+  """
+  @spec combine_mnemonics([String.t()], binary()) :: {:ok, binary()} | {:error, atom()}
+  def combine_mnemonics(mnemonics, passphrase \\ "") do
+    with :ok <- validate_passphrase(passphrase),
+         :ok <- validate_non_empty(mnemonics),
+         {:ok, shares} <- decode_all(mnemonics),
+         :ok <- validate_consistency(shares),
+         share = hd(shares),
+         {:ok, groups} <- collect_groups(shares, share.group_threshold),
+         {:ok, group_points} <- recover_group_points(groups),
+         {:ok, ems} <- Shamir.recover_secret(share.group_threshold, group_points) do
+      {:ok,
+       Cipher.decrypt(
+         ems,
+         passphrase,
+         share.iteration_exponent,
+         share.identifier,
+         share.extendable
+       )}
+    end
+  end
+
+  defp validate_secret(master_secret)
+       when is_binary(master_secret) and byte_size(master_secret) >= @min_strength_bytes and
+              rem(byte_size(master_secret), 2) == 0,
+       do: :ok
+
+  defp validate_secret(_master_secret), do: {:error, :invalid_secret_length}
+
+  defp validate_group_threshold(group_threshold, group_count)
+       when group_threshold >= 1 and group_threshold <= group_count and
+              group_count <= @max_share_count,
+       do: :ok
+
+  defp validate_group_threshold(_group_threshold, _group_count),
+    do: {:error, :invalid_group_threshold}
+
+  defp validate_groups(groups) do
+    if Enum.all?(groups, &valid_group_spec?/1) do
+      :ok
+    else
+      {:error, :invalid_member_threshold}
+    end
+  end
+
+  # A member threshold of 1 with more than one share is forbidden: every
+  # share would be the group secret verbatim, silently defeating sharing.
+  defp valid_group_spec?({1, member_count}), do: member_count == 1
+
+  defp valid_group_spec?({member_threshold, member_count}),
+    do:
+      member_threshold >= 1 and member_threshold <= member_count and
+        member_count <= @max_share_count
+
+  defp validate_passphrase(passphrase) when is_binary(passphrase) do
+    if passphrase |> :binary.bin_to_list() |> Enum.all?(&(&1 in 32..126)) do
+      :ok
+    else
+      {:error, :invalid_passphrase}
+    end
+  end
+
+  defp validate_non_empty([]), do: {:error, :empty_mnemonic_set}
+  defp validate_non_empty(_mnemonics), do: :ok
+
+  defp random_identifier(rng) do
+    <<identifier::size(@id_length_bits), _::1>> = rng.(2)
+    identifier
+  end
+
+  defp decode_all(mnemonics) do
+    Enum.reduce_while(mnemonics, {:ok, []}, fn mnemonic, {:ok, shares} ->
+      case Share.decode(mnemonic) do
+        {:ok, share} -> {:cont, {:ok, [share | shares]}}
+        {:error, _reason} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_consistency(shares) do
+    parameters =
+      Enum.map(shares, fn share ->
+        {share.identifier, share.extendable, share.iteration_exponent, share.group_threshold,
+         share.group_count, byte_size(share.share_value)}
+      end)
+
+    case Enum.uniq(parameters) do
+      [_common] -> :ok
+      _mismatching -> {:error, :mismatching_shares}
+    end
+  end
+
+  defp collect_groups(shares, group_threshold) do
+    groups = Enum.group_by(shares, & &1.group_index)
+
+    cond do
+      map_size(groups) < group_threshold -> {:error, :insufficient_groups}
+      map_size(groups) > group_threshold -> {:error, :too_many_groups}
+      true -> validate_group_members(Map.values(groups), groups)
+    end
+  end
+
+  defp validate_group_members([], groups), do: {:ok, groups}
+
+  defp validate_group_members([members | rest], groups) do
+    thresholds = members |> Enum.map(& &1.member_threshold) |> Enum.uniq()
+    member_indices = Enum.map(members, & &1.member_index)
+    member_count = length(members)
+
+    cond do
+      length(thresholds) > 1 -> {:error, :mismatching_shares}
+      length(Enum.uniq(member_indices)) != member_count -> {:error, :duplicate_member_index}
+      member_count < hd(thresholds) -> {:error, :insufficient_member_shares}
+      member_count > hd(thresholds) -> {:error, :too_many_member_shares}
+      true -> validate_group_members(rest, groups)
+    end
+  end
+
+  defp recover_group_points(groups) do
+    Enum.reduce_while(groups, {:ok, []}, fn {group_index, members}, {:ok, points} ->
+      member_points = Enum.map(members, &{&1.member_index, &1.share_value})
+
+      case Shamir.recover_secret(hd(members).member_threshold, member_points) do
+        {:ok, group_value} -> {:cont, {:ok, [{group_index, group_value} | points]}}
+        {:error, _reason} = err -> {:halt, err}
+      end
+    end)
+  end
+end

--- a/lib/slip39/share.ex
+++ b/lib/slip39/share.ex
@@ -115,8 +115,12 @@ defmodule Bitcoinex.SLIP39.Share do
     pad_bits = rem(value_words * @radix_bits, 16)
 
     if pad_bits > 8 do
-      # Rules out e.g. 21-word mnemonics, where rem(140, 16) == 12.
-      {:error, :invalid_padding}
+      # Rules out e.g. 21-word mnemonics, where rem(140, 16) == 12. Such a
+      # word count implies a share value that is not a whole number of even
+      # bytes, i.e. it can only be produced by a master secret of invalid
+      # length (official vector 40, "invalid master secret length", is the
+      # 21-word encoding of a 17-byte secret).
+      {:error, :invalid_secret_length}
     else
       # pad_bits <= 8 guarantees the trailing share value is a whole
       # number of bytes, so this match cannot fail.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bitcoinex.MixProject do
   def project do
     [
       app: :bitcoinex,
-      version: "0.1.8",
+      version: "0.2.0",
       elixir: "~> 1.11",
       package: package(),
       start_permanent: Mix.env() == :prod,

--- a/test/slip39/share_test.exs
+++ b/test/slip39/share_test.exs
@@ -140,14 +140,15 @@ defmodule Bitcoinex.SLIP39.ShareTest do
       assert Share.decode(vector_mnemonic(2)) == {:error, :invalid_padding}
     end
 
-    test "21-word mnemonic returns {:error, :invalid_padding}" do
+    test "21-word mnemonic returns {:error, :invalid_secret_length}" do
       # rem((21 - 7) * 10, 16) == 12 > 8, so 21-word mnemonics are invalid
-      # even with a correct checksum.
+      # even with a correct checksum: they can only encode a master secret
+      # of invalid (odd) length. Matches official vector 40.
       data = List.duplicate(0, 18)
       indices = data ++ Encoding.rs1024_create_checksum(data, false)
       mnemonic = indices |> Encoding.indices_to_words() |> Enum.join(" ")
 
-      assert Share.decode(mnemonic) == {:error, :invalid_padding}
+      assert Share.decode(mnemonic) == {:error, :invalid_secret_length}
     end
 
     test "vector 39 (insufficient length, 19 words) returns {:error, :invalid_mnemonic_length}" do

--- a/test/slip39_test.exs
+++ b/test/slip39_test.exs
@@ -257,6 +257,37 @@ defmodule Bitcoinex.SLIP39Test do
       assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: <<7>>) ==
                {:error, :invalid_passphrase}
     end
+
+    test "out-of-range identifier returns {:error, :invalid_identifier}" do
+      # the wire format truncates identifiers to 15 bits: an unvalidated
+      # identifier of 40_000 would encode as 7232 while the Feistel salt
+      # used 40_000, so recombination would silently yield a wrong secret
+      for bad <- [40_000, 0x8000, -1, :zero, "0"] do
+        assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, identifier: bad) ==
+                 {:error, :invalid_identifier}
+      end
+    end
+
+    test "identifier boundary values are accepted and round-trip" do
+      for identifier <- [0, 0x7FFF] do
+        assert {:ok, [mnemonics]} =
+                 SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16,
+                   identifier: identifier,
+                   rng: make_rng(41)
+                 )
+
+        assert SLIP39.combine_mnemonics(Enum.take(mnemonics, 2)) == {:ok, @secret_16}
+      end
+    end
+
+    test "out-of-range iteration exponent returns {:error, :invalid_iteration_exponent}" do
+      # the wire format truncates the exponent to 4 bits: e = 16 would
+      # encode as 0 while encryption used 10_000 <<< 16 iterations
+      for bad <- [16, -1, 1.0] do
+        assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, iteration_exponent: bad) ==
+                 {:error, :invalid_iteration_exponent}
+      end
+    end
   end
 
   describe "combine_mnemonics/2 validation" do

--- a/test/slip39_test.exs
+++ b/test/slip39_test.exs
@@ -1,0 +1,362 @@
+defmodule Bitcoinex.SLIP39Test do
+  use ExUnit.Case
+  use ExUnitProperties
+
+  alias Bitcoinex.ExtendedKey
+  alias Bitcoinex.SLIP39
+  alias Bitcoinex.SLIP39.Share
+
+  doctest Bitcoinex.SLIP39
+
+  # Official SLIP-39 test vectors, byte-identical to
+  # https://raw.githubusercontent.com/trezor/python-shamir-mnemonic/master/vectors.json
+  # (sha256: 13ebecebdd869dd2bc2cdf69e7ce3a158cf106cac76c39d17682b1c6cdabbdc4).
+  # Each vector is [description, mnemonics, master_secret_hex, xprv]; the 15
+  # valid vectors have a non-empty master_secret_hex and use passphrase
+  # "TREZOR"; the 30 invalid vectors have an empty master_secret_hex.
+  @vectors_path Path.join(__DIR__, "data/slip39_vectors.json")
+  @external_resource @vectors_path
+  @vectors @vectors_path |> File.read!() |> JSON.decode!()
+
+  @secret_16 Base.decode16!("4142434445464748494a4b4c4d4e4f50", case: :lower)
+  @secret_32 Base.decode16!(
+               "989baf9dcaad5b10a5eec78afcaf0a1cc762c9e3d7cadef8aac343109fd90c69",
+               case: :lower
+             )
+
+  # Deterministic rng stub: a counter-keyed SHA-256 stream. Every call
+  # produces different (but reproducible) bytes; no CSPRNG is used in tests.
+  defp make_rng(seed) do
+    counter = :atomics.new(1, signed: false)
+
+    fn byte_count ->
+      call_index = :atomics.add_get(counter, 1, 1)
+      expand_bytes(<<seed::unsigned-64, call_index::unsigned-64>>, byte_count, <<>>)
+    end
+  end
+
+  defp expand_bytes(_key, byte_count, acc) when byte_size(acc) >= byte_count,
+    do: binary_part(acc, 0, byte_count)
+
+  defp expand_bytes(key, byte_count, acc) do
+    block = :crypto.hash(:sha256, [key, <<byte_size(acc)::unsigned-32>>])
+    expand_bytes(key, byte_count, acc <> block)
+  end
+
+  defp combinations(_list, 0), do: [[]]
+  defp combinations([], _k), do: []
+
+  defp combinations([head | tail], k) do
+    for(combo <- combinations(tail, k - 1), do: [head | combo]) ++ combinations(tail, k)
+  end
+
+  # Maps each invalid official vector's description to the specific error
+  # atom combine_mnemonics/2 must return for it.
+  defp expected_error(description) do
+    cond do
+      description =~ "invalid checksum" -> :invalid_checksum
+      description =~ "invalid padding" -> :invalid_padding
+      description =~ "greater group threshold than group counts" -> :invalid_group_threshold
+      description =~ "different identifiers" -> :mismatching_shares
+      description =~ "different iteration exponents" -> :mismatching_shares
+      description =~ "mismatching group thresholds" -> :mismatching_shares
+      description =~ "mismatching group counts" -> :mismatching_shares
+      description =~ "mismatching member thresholds" -> :mismatching_shares
+      description =~ "duplicate member indices" -> :duplicate_member_index
+      description =~ "invalid digest" -> :invalid_digest
+      description =~ "Insufficient number of groups" -> :insufficient_groups
+      description =~ "insufficient number of members" -> :insufficient_member_shares
+      description =~ "Basic sharing 2-of-3" -> :insufficient_member_shares
+      description =~ "insufficient length" -> :invalid_mnemonic_length
+      description =~ "invalid master secret length" -> :invalid_secret_length
+    end
+  end
+
+  describe "official vectors" do
+    test "vector file contains 15 valid and 30 invalid vectors" do
+      assert length(@vectors) == 45
+      assert Enum.count(@vectors, fn [_d, _m, ms_hex, _x] -> ms_hex != "" end) == 15
+      assert Enum.count(@vectors, fn [_d, _m, ms_hex, _x] -> ms_hex == "" end) == 30
+    end
+
+    test "all valid vectors recover the master secret and derive the xprv" do
+      for [description, mnemonics, ms_hex, xprv] <- @vectors, ms_hex != "" do
+        ms = Base.decode16!(ms_hex, case: :lower)
+
+        assert SLIP39.combine_mnemonics(mnemonics, "TREZOR") == {:ok, ms},
+               "vector failed: #{description}"
+
+        assert {:ok, xkey} = ExtendedKey.seed_to_master_private_key(ms)
+
+        assert ExtendedKey.display_extended_key(xkey) == xprv,
+               "xprv mismatch for vector: #{description}"
+      end
+    end
+
+    test "all invalid vectors return the specific error atom for their description" do
+      for [description, mnemonics, ms_hex, _xprv] <- @vectors, ms_hex == "" do
+        assert SLIP39.combine_mnemonics(mnemonics, "TREZOR") ==
+                 {:error, expected_error(description)},
+               "vector failed: #{description}"
+      end
+    end
+  end
+
+  describe "generate_mnemonics/4 + combine_mnemonics/2 round-trips" do
+    test "single group 2-of-3: every 2-subset recovers the secret" do
+      rng = make_rng(1)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, rng: rng)
+      assert length(shares) == 3
+
+      for subset <- combinations(shares, 2) do
+        assert SLIP39.combine_mnemonics(subset) == {:ok, @secret_16}
+      end
+    end
+
+    test "multi-group 2-of-[(2,3),(3,5),(1,1)]: exact-threshold subsets of any 2 groups" do
+      rng = make_rng(2)
+
+      assert {:ok, [g0, g1, g2]} =
+               SLIP39.generate_mnemonics(2, [{2, 3}, {3, 5}, {1, 1}], @secret_32,
+                 passphrase: "TREZOR",
+                 rng: rng
+               )
+
+      assert length(g0) == 3
+      assert length(g1) == 5
+      assert length(g2) == 1
+
+      # groups 0 + 1
+      assert SLIP39.combine_mnemonics(Enum.take(g0, 2) ++ Enum.take(g1, 3), "TREZOR") ==
+               {:ok, @secret_32}
+
+      # groups 0 + 2, a different member subset of group 0
+      assert SLIP39.combine_mnemonics([Enum.at(g0, 0), Enum.at(g0, 2)] ++ g2, "TREZOR") ==
+               {:ok, @secret_32}
+
+      # groups 1 + 2, a different member subset of group 1
+      assert SLIP39.combine_mnemonics(
+               g2 ++ [Enum.at(g1, 4), Enum.at(g1, 1), Enum.at(g1, 3)],
+               "TREZOR"
+             ) == {:ok, @secret_32}
+    end
+
+    test "16 groups of (1,1) with group threshold 16" do
+      rng = make_rng(3)
+      groups = List.duplicate({1, 1}, 16)
+
+      assert {:ok, group_mnemonics} = SLIP39.generate_mnemonics(16, groups, @secret_16, rng: rng)
+
+      all_shares = List.flatten(group_mnemonics)
+      assert length(all_shares) == 16
+      assert SLIP39.combine_mnemonics(all_shares) == {:ok, @secret_16}
+    end
+
+    test "share order does not matter" do
+      rng = make_rng(4)
+
+      assert {:ok, [g0, g1]} =
+               SLIP39.generate_mnemonics(2, [{2, 3}, {2, 2}], @secret_16, rng: rng)
+
+      subset = Enum.take(g0, 2) ++ g1
+
+      for shuffled <- [Enum.reverse(subset), Enum.shuffle(subset), Enum.shuffle(subset)] do
+        assert SLIP39.combine_mnemonics(shuffled) == {:ok, @secret_16}
+      end
+    end
+
+    test "extendable: true and extendable: false both round-trip" do
+      for extendable <- [true, false] do
+        rng = make_rng(5)
+
+        assert {:ok, [shares]} =
+                 SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16,
+                   extendable: extendable,
+                   rng: rng
+                 )
+
+        assert {:ok, %Share{extendable: ^extendable}} = Share.decode(hd(shares))
+        assert SLIP39.combine_mnemonics(Enum.take(shares, 2)) == {:ok, @secret_16}
+      end
+    end
+
+    test "explicit identifier and iteration exponent are threaded through" do
+      rng = make_rng(6)
+
+      assert {:ok, [shares]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16,
+                 identifier: 12_345,
+                 iteration_exponent: 1,
+                 extendable: false,
+                 rng: rng
+               )
+
+      assert {:ok, %Share{identifier: 12_345, iteration_exponent: 1}} = Share.decode(hd(shares))
+      assert SLIP39.combine_mnemonics(shares) == {:ok, @secret_16}
+    end
+
+    test "wrong passphrase yields a different master secret, not an error" do
+      rng = make_rng(7)
+
+      assert {:ok, [shares]} =
+               SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: "TREZOR", rng: rng)
+
+      subset = Enum.take(shares, 2)
+
+      assert SLIP39.combine_mnemonics(subset, "TREZOR") == {:ok, @secret_16}
+
+      # SLIP-39 plausible deniability: a wrong passphrase silently decrypts
+      # to a different master secret.
+      assert {:ok, wrong_ms} = SLIP39.combine_mnemonics(subset, "NOT TREZOR")
+      assert wrong_ms != @secret_16
+      assert byte_size(wrong_ms) == byte_size(@secret_16)
+    end
+  end
+
+  describe "generate_mnemonics/4 validation" do
+    test "master secret shorter than 16 bytes returns {:error, :invalid_secret_length}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], :binary.copy(<<1>>, 15)) ==
+               {:error, :invalid_secret_length}
+    end
+
+    test "master secret of odd length returns {:error, :invalid_secret_length}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], :binary.copy(<<1>>, 17)) ==
+               {:error, :invalid_secret_length}
+    end
+
+    test "group threshold above the group count returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(3, [{2, 3}, {2, 3}], @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "group threshold of 0 returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(0, [{2, 3}], @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "more than 16 groups returns {:error, :invalid_group_threshold}" do
+      assert SLIP39.generate_mnemonics(1, List.duplicate({1, 1}, 17), @secret_16) ==
+               {:error, :invalid_group_threshold}
+    end
+
+    test "member threshold above the member count returns {:error, :invalid_member_threshold}" do
+      assert SLIP39.generate_mnemonics(1, [{3, 2}], @secret_16) ==
+               {:error, :invalid_member_threshold}
+    end
+
+    test "member threshold of 1 with more than 1 share returns {:error, :invalid_member_threshold}" do
+      assert SLIP39.generate_mnemonics(1, [{1, 2}], @secret_16) ==
+               {:error, :invalid_member_threshold}
+    end
+
+    test "non-printable-ASCII passphrase returns {:error, :invalid_passphrase}" do
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: "café") ==
+               {:error, :invalid_passphrase}
+
+      assert SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, passphrase: <<7>>) ==
+               {:error, :invalid_passphrase}
+    end
+  end
+
+  describe "combine_mnemonics/2 validation" do
+    test "empty mnemonic list returns {:error, :empty_mnemonic_set}" do
+      assert SLIP39.combine_mnemonics([]) == {:error, :empty_mnemonic_set}
+    end
+
+    test "non-printable-ASCII passphrase returns {:error, :invalid_passphrase}" do
+      assert SLIP39.combine_mnemonics(["any mnemonic"], "café") == {:error, :invalid_passphrase}
+      assert SLIP39.combine_mnemonics(["any mnemonic"], <<7>>) == {:error, :invalid_passphrase}
+    end
+
+    test "more groups than the group threshold returns {:error, :too_many_groups}" do
+      rng = make_rng(8)
+
+      assert {:ok, groups} =
+               SLIP39.generate_mnemonics(2, [{1, 1}, {1, 1}, {1, 1}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(List.flatten(groups)) == {:error, :too_many_groups}
+    end
+
+    test "fewer groups than the group threshold returns {:error, :insufficient_groups}" do
+      rng = make_rng(9)
+
+      assert {:ok, [g0, _g1]} =
+               SLIP39.generate_mnemonics(2, [{2, 2}, {2, 2}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(g0) == {:error, :insufficient_groups}
+    end
+
+    test "more member shares than the member threshold returns {:error, :too_many_member_shares}" do
+      rng = make_rng(10)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{2, 3}], @secret_16, rng: rng)
+      assert SLIP39.combine_mnemonics(shares) == {:error, :too_many_member_shares}
+    end
+
+    test "fewer member shares than the member threshold returns {:error, :insufficient_member_shares}" do
+      rng = make_rng(11)
+
+      assert {:ok, [shares]} = SLIP39.generate_mnemonics(1, [{3, 5}], @secret_16, rng: rng)
+
+      assert SLIP39.combine_mnemonics(Enum.take(shares, 2)) ==
+               {:error, :insufficient_member_shares}
+    end
+
+    test "shares from different share sets return {:error, :mismatching_shares}" do
+      assert {:ok, [[share_a | _]]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16, rng: make_rng(12))
+
+      assert {:ok, [[_, share_b]]} =
+               SLIP39.generate_mnemonics(1, [{2, 2}], @secret_16, rng: make_rng(13))
+
+      assert SLIP39.combine_mnemonics([share_a, share_b]) == {:error, :mismatching_shares}
+    end
+  end
+
+  # 1 <= t <= n <= 4, excluding the forbidden t == 1 && n > 1 case.
+  defp group_spec_generator do
+    gen all(
+          member_threshold <- integer(1..4),
+          member_count <-
+            if(member_threshold == 1,
+              do: constant(1),
+              else: integer(member_threshold..4)
+            )
+        ) do
+      {member_threshold, member_count}
+    end
+  end
+
+  describe "properties" do
+    property "full-stack round-trip: exact-threshold shuffled subsets recover the secret" do
+      check all(
+              master_secret <- one_of([binary(length: 16), binary(length: 32)]),
+              groups <- list_of(group_spec_generator(), min_length: 1, max_length: 4),
+              group_threshold <- integer(1..length(groups)),
+              seed <- integer(0..1_000_000),
+              max_runs: 25
+            ) do
+        rng = make_rng(seed)
+
+        assert {:ok, group_mnemonics} =
+                 SLIP39.generate_mnemonics(group_threshold, groups, master_secret,
+                   iteration_exponent: 0,
+                   rng: rng
+                 )
+
+        subset =
+          group_mnemonics
+          |> Enum.zip(groups)
+          |> Enum.shuffle()
+          |> Enum.take(group_threshold)
+          |> Enum.flat_map(fn {mnemonics, {member_threshold, _member_count}} ->
+            mnemonics |> Enum.shuffle() |> Enum.take(member_threshold)
+          end)
+          |> Enum.shuffle()
+
+        assert SLIP39.combine_mnemonics(subset) == {:ok, master_secret}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stack: S0 → S1 → S2 → S3 → S4 → S5 → **S6** — final PR (spec §3.9)

- `Bitcoinex.SLIP39.generate_mnemonics/4`: validation (secret length/thresholds/printable-ASCII passphrase), Feistel encrypt, two-level group→member Shamir split, Share encoding. CSPRNG default (`:crypto.strong_rand_bytes/1`), injectable rng documented test-only
- `Bitcoinex.SLIP39.combine_mnemonics/2`: decode, cross-share consistency, group/member threshold checks, two-level recover, decrypt
- **All 45 official trezor vectors pass** — 15 valid (MS + end-to-end xprv via `ExtendedKey`), 30 invalid each asserting its *specific* error atom
- Full-stack property: random MS/config, exact-threshold shuffled subsets round-trip
- CHANGELOG, version 0.1.8 → 0.2.0, README features list

Deviation from spec §3.8 (vectors won): `Share.decode` now returns `:invalid_secret_length` (not `:invalid_padding`) for pad_bits > 8 — official vector 40 names that case 'invalid master secret length', and it's the only shape that description can take. Spec doc updated in the final sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)