### PR TITLE
Parse all r fields (route hints) from BOLT11 invoices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped, and invoices with more than 20 route hints are rejected during parsing with `:too_many_private_routes`.
+- BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped.
 - BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version `f` fields without blocking later valid ones. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).
+### Removed
+- The lnd-specific limit of 20 route hints per invoice (`{:error, :too_many_private_routes}`). BOLT11 places no limit on the number of `r` fields, so invoices with more than 20 route hints now decode successfully.
 
 ## [0.1.8] - 2024-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route.
+
 ## [0.1.8] - 2024-03-01
 ### Added
 - Fix warning emitted from String.slice with negative step when parsing amountful BOLT11 invoices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped.
-- BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version `f` fields without blocking later valid ones. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).
+- BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version and empty `f` fields without blocking later valid ones or failing the decode. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).
 ### Removed
 - The lnd-specific limit of 20 route hints per invoice (`{:error, :too_many_private_routes}`). BOLT11 places no limit on the number of `r` fields, so invoices with more than 20 route hints now decode successfully.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route.
+- BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped, and invoices with more than 20 route hints are rejected during parsing with `:too_many_private_routes`.
+- BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version `f` fields without blocking later valid ones. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).
 
 ## [0.1.8] - 2024-03-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Decode a Lightning Network invoice:
       description_hash: nil,
       destination: "03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad",
       expiry: 60,
-      fallback_address: nil,
+      fallback_addresses: [],
       min_final_cltv_expiry: 18,
       network: :mainnet,
       payment_hash: "0001020304050607080900010203040506070809000102030405060708090102",

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -178,20 +178,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   end
 
   defp parse_tagged_fields(data, network) when is_list(data) do
-    with {:ok, acc} <- do_parse_tagged_fields(data, %{}, network) do
-      # multi-valued fields are accumulated by prepending; restore encounter order
-      {:ok,
-       acc
-       |> reverse_multi_field(:route_hints)
-       |> reverse_multi_field(:fallback_addresses)}
-    end
+    do_parse_tagged_fields(data, %{}, network)
   end
-
-  defp reverse_multi_field(acc, key) when is_map_key(acc, key) do
-    Map.update!(acc, key, &Enum.reverse/1)
-  end
-
-  defp reverse_multi_field(acc, _key), do: acc
 
   defp do_parse_tagged_fields([type, data_length1, data_length2 | rest], acc, network) do
     data_length = data_length1 <<< 5 ||| data_length2
@@ -240,9 +228,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
             {:ok, acc}
 
           {:ok, hop_hints} ->
-            # prepended so accumulation stays linear on unbounded invoices;
-            # parse_tagged_fields restores encounter order
-            {:ok, Map.update(acc, :route_hints, [hop_hints], &[hop_hints | &1])}
+            {:ok, Map.update(acc, :route_hints, [hop_hints], &(&1 ++ [hop_hints]))}
 
           {:error, error} ->
             {:error, error}
@@ -267,10 +253,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
             {:ok, acc}
 
           {:ok, fallback_address} ->
-            # prepended so accumulation stays linear on unbounded invoices;
-            # parse_tagged_fields restores encounter order
             {:ok,
-             Map.update(acc, :fallback_addresses, [fallback_address], &[fallback_address | &1])}
+             Map.update(acc, :fallback_addresses, [fallback_address], &(&1 ++ [fallback_address]))}
 
           {:error, error} ->
             {:error, error}

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -178,10 +178,16 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       # multi-valued fields are accumulated by prepending; restore encounter order
       {:ok,
        acc
-       |> Map.replace_lazy(:route_hints, &Enum.reverse/1)
-       |> Map.replace_lazy(:fallback_addresses, &Enum.reverse/1)}
+       |> reverse_multi_field(:route_hints)
+       |> reverse_multi_field(:fallback_addresses)}
     end
   end
+
+  defp reverse_multi_field(acc, key) when is_map_key(acc, key) do
+    Map.update!(acc, key, &Enum.reverse/1)
+  end
+
+  defp reverse_multi_field(acc, _key), do: acc
 
   defp do_parse_tagged_fields([type, data_length1, data_length2 | rest], acc, network) do
     data_length = data_length1 <<< 5 ||| data_length2
@@ -230,6 +236,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
             {:ok, acc}
 
           {:ok, hop_hints} ->
+            # prepended so accumulation stays linear on unbounded invoices;
+            # parse_tagged_fields restores encounter order
             {:ok, Map.update(acc, :route_hints, [hop_hints], &[hop_hints | &1])}
 
           {:error, error} ->
@@ -255,6 +263,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
             {:ok, acc}
 
           {:ok, fallback_address} ->
+            # prepended so accumulation stays linear on unbounded invoices;
+            # parse_tagged_fields restores encounter order
             {:ok,
              Map.update(acc, :fallback_addresses, [fallback_address], &[fallback_address | &1])}
 
@@ -387,8 +397,10 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     end
   end
 
+  # an empty f field carries no version, so there is nothing to decode;
+  # skip it (like an unknown version) rather than fail the whole invoice
   defp parse_fallback_address([], _network) do
-    {:error, :empty_fallback_address}
+    {:ok, nil}
   end
 
   defp parse_fallback_address([version | rest], network) do

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -42,7 +42,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
           description_hash: String.t() | nil,
           fallback_address: String.t() | nil,
           min_final_cltv_expiry: non_neg_integer,
-          route_hints: list(HopHint.t())
+          # each route hint (one per r field) is a list of one or more hops
+          route_hints: list(list(HopHint.t()))
         }
 
   @prefix "ln"
@@ -216,18 +217,15 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
           end
         end
 
-      # r field HopHints
+      # r field HopHints. BOLT#11 allows multiple r fields, each containing
+      # one full route hint (a list of one or more hops), so accumulate them.
       3 ->
-        if Map.has_key?(acc, :route_hints) do
-          {:ok, acc}
-        else
-          case parse_hop_hints(data) do
-            {:ok, hop_hints} ->
-              {:ok, Map.put(acc, :route_hints, hop_hints)}
+        case parse_hop_hints(data) do
+          {:ok, hop_hints} ->
+            {:ok, Map.update(acc, :route_hints, [hop_hints], &(&1 ++ [hop_hints]))}
 
-            {:error, error} ->
-              {:error, error}
-          end
+          {:error, error} ->
+            {:error, error}
         end
 
       # x field

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -57,8 +57,6 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   @sha256_hash_base32_length 52
   @pubkey_base32_length 53
   @hop_hint_length 51
-  # lnd has this limit but BOLT#11 itself does not
-  @max_route_hints 20
   @type error :: atom
 
   @doc """
@@ -124,9 +122,6 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
 
       !is_nil(invoice.description) && !is_nil(invoice.description_hash) ->
         {:error, :both_description_and_description_hash_missing}
-
-      Enum.count(invoice.route_hints) > @max_route_hints ->
-        {:error, :too_many_private_routes}
 
       String.length(invoice.payment_hash) != 64 ->
         {:error, :invalid_payment_hash_length}
@@ -235,15 +230,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
             {:ok, acc}
 
           {:ok, hop_hints} ->
-            route_hints = Map.get(acc, :route_hints, [])
-
-            # enforced during parsing so a hostile invoice packed with r fields
-            # is rejected before accumulating unbounded work
-            if Enum.count(route_hints) >= @max_route_hints do
-              {:error, :too_many_private_routes}
-            else
-              {:ok, Map.put(acc, :route_hints, [hop_hints | route_hints])}
-            end
+            {:ok, Map.update(acc, :route_hints, [hop_hints], &[hop_hints | &1])}
 
           {:error, error} ->
             {:error, error}

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -24,7 +24,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     :timestamp,
     :description,
     :description_hash,
-    :fallback_address,
+    fallback_addresses: [],
     route_hints: [],
     expiry: @default_expiry,
     min_final_cltv_expiry: @default_min_final_cltv_expiry
@@ -40,7 +40,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
           # description and description_hash are either both non-nil or nil
           description: String.t() | nil,
           description_hash: String.t() | nil,
-          fallback_address: String.t() | nil,
+          # one per f field with a known version, most-preferred first
+          fallback_addresses: list(String.t()),
           min_final_cltv_expiry: non_neg_integer,
           # each route hint (one per r field) is a list of one or more hops
           route_hints: list(list(HopHint.t()))
@@ -56,6 +57,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   @sha256_hash_base32_length 52
   @pubkey_base32_length 53
   @hop_hint_length 51
+  # lnd has this limit but BOLT#11 itself does not
+  @max_route_hints 20
   @type error :: atom
 
   @doc """
@@ -122,8 +125,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       !is_nil(invoice.description) && !is_nil(invoice.description_hash) ->
         {:error, :both_description_and_description_hash_missing}
 
-      # lnd have this but not in Bolt11. do we need to enforce this?
-      Enum.count(invoice.route_hints) > 20 ->
+      Enum.count(invoice.route_hints) > @max_route_hints ->
         {:error, :too_many_private_routes}
 
       String.length(invoice.payment_hash) != 64 ->
@@ -177,7 +179,13 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   end
 
   defp parse_tagged_fields(data, network) when is_list(data) do
-    do_parse_tagged_fields(data, %{}, network)
+    with {:ok, acc} <- do_parse_tagged_fields(data, %{}, network) do
+      # multi-valued fields are accumulated by prepending; restore encounter order
+      {:ok,
+       acc
+       |> Map.replace_lazy(:route_hints, &Enum.reverse/1)
+       |> Map.replace_lazy(:fallback_addresses, &Enum.reverse/1)}
+    end
   end
 
   defp do_parse_tagged_fields([type, data_length1, data_length2 | rest], acc, network) do
@@ -221,8 +229,21 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       # one full route hint (a list of one or more hops), so accumulate them.
       3 ->
         case parse_hop_hints(data) do
+          # BOLT#11 requires an r field to contain "one or more entries",
+          # so an empty one is invalid; skip it rather than fail
+          {:ok, []} ->
+            {:ok, acc}
+
           {:ok, hop_hints} ->
-            {:ok, Map.update(acc, :route_hints, [hop_hints], &(&1 ++ [hop_hints]))}
+            route_hints = Map.get(acc, :route_hints, [])
+
+            # enforced during parsing so a hostile invoice packed with r fields
+            # is rejected before accumulating unbounded work
+            if Enum.count(route_hints) >= @max_route_hints do
+              {:error, :too_many_private_routes}
+            else
+              {:ok, Map.put(acc, :route_hints, [hop_hints | route_hints])}
+            end
 
           {:error, error} ->
             {:error, error}
@@ -237,18 +258,21 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
           {:ok, Map.put(acc, :expiry, expiry)}
         end
 
-      # f field fallback address
+      # f field fallback address. BOLT#11 allows one or more f fields
+      # (most-preferred first), so accumulate them.
       9 ->
-        if Map.has_key?(acc, :fallback_address) do
-          {:ok, acc}
-        else
-          case parse_fallback_address(data, network) do
-            {:ok, fallback_address} ->
-              {:ok, Map.put(acc, :fallback_address, fallback_address)}
+        case parse_fallback_address(data, network) do
+          # BOLT#11 readers "MUST skip over f fields that use an unknown version";
+          # a later f field may still carry a known version
+          {:ok, nil} ->
+            {:ok, acc}
 
-            {:error, error} ->
-              {:error, error}
-          end
+          {:ok, fallback_address} ->
+            {:ok,
+             Map.update(acc, :fallback_addresses, [fallback_address], &[fallback_address | &1])}
+
+          {:error, error} ->
+            {:error, error}
         end
 
       # d field

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -61,6 +61,10 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
 
   @doc """
    Decode accepts a Bech32 encoded string invoice and deserializes it.
+
+   BOLT#11 places no upper bound on invoice length (it lifts BIP-173's
+   90-character limit), so no size limit is enforced here; callers decoding
+   untrusted input should bound the string length themselves.
   """
   @spec decode(String.t()) :: {:ok, t} | {:error, error}
   def decode(invoice) when is_binary(invoice) do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -149,7 +149,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_testnet_P2PKH,
+          fallback_addresses: [test_address_testnet_P2PKH],
           min_final_cltv_expiry: 18
         }
       },
@@ -176,7 +176,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2PKH,
+          fallback_addresses: [test_address_mainnet_P2PKH],
           route_hints: [testSingleHop],
           min_final_cltv_expiry: 18
         }
@@ -191,7 +191,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2PKH,
+          fallback_addresses: [test_address_mainnet_P2PKH],
           route_hints: [testDoubleHop],
           min_final_cltv_expiry: 18
         }
@@ -207,7 +207,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2PKH,
+          fallback_addresses: [test_address_mainnet_P2PKH],
           route_hints: [
             testSingleHop,
             [
@@ -265,6 +265,38 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           min_final_cltv_expiry: 80
         }
       },
+      # 1 hophint followed by an empty r field. BOLT#11 requires each r field to
+      # contain one or more entries, so the empty r field is skipped.
+      {
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvrqqtc7hun0s30rh0gq0a975wcudnzvsphujjyhtw3ten8xkur5ms8qpcjxfk4sty093gtrhfqsxsns8lf8ge7twyx6ve80wd0xhsglardcpfzqtth",
+        %Invoice{
+          network: :mainnet,
+          destination: test_pubkey,
+          payment_hash: test_payment_hash,
+          amount_msat: 2_000_000_000,
+          timestamp: 1_496_314_658,
+          description_hash: test_description_hash_slice,
+          fallback_addresses: [test_address_mainnet_P2PKH],
+          route_hints: [testSingleHop],
+          min_final_cltv_expiry: 18
+        }
+      },
+      # three f fields: P2PKH, then one with an unknown version (19, skipped),
+      # then P2WPKH. All known-version fallback addresses are collected in order.
+      {
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvfqynpzrfppqw508d6qejxtdg4y5r3zarvary0c5xw7kyjc3xmnnm03spelf55p7jd4z9rdlj7zenmlr5hd96s8f939me8gytjt4rzcg4x4gz8z8hssrzk8e20q89qnrngz274vswzl2rg0w3hgp6wrvs7",
+        %Invoice{
+          network: :mainnet,
+          destination: test_pubkey,
+          payment_hash: test_payment_hash,
+          amount_msat: 2_000_000_000,
+          timestamp: 1_496_314_658,
+          description_hash: test_description_hash_slice,
+          fallback_addresses: [test_address_mainnet_P2PKH, test_address_mainnet_P2WPKH],
+          route_hints: [testSingleHop],
+          min_final_cltv_expiry: 18
+        }
+      },
       # On mainnet, with fallback (p2sh) address 3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX
       {
         "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfppj3a24vwu6r8ejrss3axul8rxldph2q7z9kk822r8plup77n9yq5ep2dfpcydrjwzxs0la84v3tfw43t3vqhek7f05m6uf8lmfkjn7zv7enn76sq65d8u9lxav2pl6x3xnc2ww3lqpagnh0u",
@@ -275,7 +307,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2SH,
+          fallback_addresses: [test_address_mainnet_P2SH],
           min_final_cltv_expiry: 18
         }
       },
@@ -289,7 +321,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2WPKH,
+          fallback_addresses: [test_address_mainnet_P2WPKH],
           min_final_cltv_expiry: 18
         }
       },
@@ -303,7 +335,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           amount_msat: 2_000_000_000,
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
-          fallback_address: test_address_mainnet_P2WSH,
+          fallback_addresses: [test_address_mainnet_P2WSH],
           min_final_cltv_expiry: 18
         }
       },
@@ -432,7 +464,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           timestamp: 1_496_314_658,
           description_hash: "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
           min_final_cltv_expiry: 18,
-          fallback_address: "3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX"
+          fallback_addresses: ["3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX"]
         }
       },
       {
@@ -445,7 +477,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           timestamp: 1_496_314_658,
           description_hash: "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
           min_final_cltv_expiry: 18,
-          fallback_address: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+          fallback_addresses: ["bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"]
         }
       },
       {
@@ -458,7 +490,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           timestamp: 1_496_314_658,
           description_hash: "3925b6f67e2c340036ed12093dd44e0368df1b6ea26c53dbe4811f58fd5db8c1",
           min_final_cltv_expiry: 18,
-          fallback_address: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+          fallback_addresses: ["bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"]
         }
       },
       {
@@ -577,6 +609,20 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
         assert {:ok, decoded_invoice} = Invoice.decode(valid_encoded_invoice)
         assert decoded_invoice == invoice
       end
+    end
+
+    test "fail to decode an invoice with more than 20 route hints" do
+      # the 1-hophint test vector with 20 extra single-hop r fields appended
+      # (21 route hints total), re-signed with the BOLT#11 spec test key
+      invoice =
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqv" <>
+          String.duplicate(
+            "rzjqw0q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qcyq5rqwzqfpgqqqqqzqqqqq8sqqs",
+            20
+          ) <>
+          "2s6kt43k6yavner648k8394mdvhuaamke6rp6tueag8h5qczq6w3c9yhq30snnj3httslvh8af2acrdffrmpsrnupjmumuy074378kqp7dqpmh"
+
+      assert {:error, :too_many_private_routes} = Invoice.decode(invoice)
     end
 
     test "fail to decode with invalid segwit addresses in mainnet", %{

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -665,6 +665,31 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
                )
     end
 
+    test "fail to decode when a later r field is malformed" do
+      # the 1-hophint test vector with a second r field appended whose data
+      # (10 bytes) is not a multiple of 51. Every r field is parsed, so a
+      # malformed one fails the decode even when an earlier r field is valid.
+      # (Tagged fields are parsed before signature verification, so the
+      # spliced-in field doesn't require re-signing.)
+      invoice =
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvrqsppppppppppppppppncsk57n4v9ehw86wq8fzvjejhv9z3w3q5zh6qkql005x9xl240ch23jk79ujzvr4hsmmafyxghpqe79psktnjl668ntaf4ne7ucs5csqp7a8gm"
+
+      assert {:error, :invalid_hop_hint_data_length} = Invoice.decode(invoice)
+    end
+
+    test "fail to decode when a later f field has a known version but invalid payload" do
+      # the 1-hophint test vector with a version-0 f field appended whose
+      # witness program is 25 bytes (must be 20 or 32). Only unknown-version
+      # and empty f fields are skipped; a known-version f field with an
+      # invalid payload fails the decode even when an earlier f field was
+      # valid. (Tagged fields are parsed before signature verification, so
+      # the spliced-in field doesn't require re-signing.)
+      invoice =
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvfpfqzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzncsk57n4v9ehw86wq8fzvjejhv9z3w3q5zh6qkql005x9xl240ch23jk79ujzvr4hsmmafyxghpqe79psktnjl668ntaf4ne7ucs5csq0spr8d"
+
+      assert {:error, :invalid_witness_program_length} = Invoice.decode(invoice)
+    end
+
     test "fail to decode with invalid segwit addresses in mainnet", %{
       invalid_encoded_invoices: invalid_encoded_invoices
     } do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -611,9 +611,10 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
       end
     end
 
-    test "fail to decode an invoice with more than 20 route hints" do
+    test "decode an invoice with 21 route hints" do
       # the 1-hophint test vector with 20 extra single-hop r fields appended
-      # (21 route hints total), re-signed with the BOLT#11 spec test key
+      # (21 route hints total), re-signed with the BOLT#11 spec test key.
+      # BOLT#11 places no limit on the number of r fields.
       invoice =
         "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqv" <>
           String.duplicate(
@@ -622,7 +623,34 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           ) <>
           "2s6kt43k6yavner648k8394mdvhuaamke6rp6tueag8h5qczq6w3c9yhq30snnj3httslvh8af2acrdffrmpsrnupjmumuy074378kqp7dqpmh"
 
-      assert {:error, :too_many_private_routes} = Invoice.decode(invoice)
+      assert {:ok, %Invoice{route_hints: route_hints}} = Invoice.decode(invoice)
+      assert Enum.count(route_hints) == 21
+
+      assert hd(route_hints) == [
+               %HopHint{
+                 node_id: "029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255",
+                 channel_id: 0x0102030405060708,
+                 fee_base_m_sat: 0,
+                 fee_proportional_millionths: 20,
+                 cltv_expiry_delta: 3
+               }
+             ]
+
+      # each appended r field carries the same single-hop route hint
+      assert Enum.drop(route_hints, 1) ==
+               List.duplicate(
+                 [
+                   %HopHint{
+                     node_id:
+                       "039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255",
+                     channel_id: 0x030405060708090A,
+                     fee_base_m_sat: 2,
+                     fee_proportional_millionths: 30,
+                     cltv_expiry_delta: 4
+                   }
+                 ],
+                 20
+               )
     end
 
     test "fail to decode with invalid segwit addresses in mainnet", %{

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -177,7 +177,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
           fallback_address: test_address_mainnet_P2PKH,
-          route_hints: testSingleHop,
+          route_hints: [testSingleHop],
           min_final_cltv_expiry: 18
         }
       },
@@ -192,7 +192,34 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           timestamp: 1_496_314_658,
           description_hash: test_description_hash_slice,
           fallback_address: test_address_mainnet_P2PKH,
-          route_hints: testDoubleHop,
+          route_hints: [testDoubleHop],
+          min_final_cltv_expiry: 18
+        }
+      },
+      # two r fields (two route hints of one hop each), signed with the BOLT#11
+      # spec test key. All r fields must be parsed, not just the first.
+      {
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvrzjqw0q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qcyq5rqwzqfpgqqqqqzqqqqq8sqqst07cl8ma7yr3zn0pucpf3e85nxrhzpsnsdldmzhgr29u7586h60se4jazfls8u9py6g3clfd8ljrsvq7d6s2pwesmkwnaayvplyr2scpnqyw9d",
+        %Invoice{
+          network: :mainnet,
+          destination: test_pubkey,
+          payment_hash: test_payment_hash,
+          amount_msat: 2_000_000_000,
+          timestamp: 1_496_314_658,
+          description_hash: test_description_hash_slice,
+          fallback_address: test_address_mainnet_P2PKH,
+          route_hints: [
+            testSingleHop,
+            [
+              %HopHint{
+                node_id: testHopHintPubkey2,
+                channel_id: 0x030405060708090A,
+                fee_base_m_sat: 2,
+                fee_proportional_millionths: 30,
+                cltv_expiry_delta: 4
+              }
+            ]
+          ],
           min_final_cltv_expiry: 18
         }
       },
@@ -289,13 +316,15 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           min_final_cltv_expiry: 10,
           expiry: 604_800,
           route_hints: [
-            %HopHint{
-              node_id: testHopHintPubkey3,
-              channel_id: 0x08FE4E000CF00001,
-              fee_base_m_sat: 1000,
-              fee_proportional_millionths: 2500,
-              cltv_expiry_delta: 40
-            }
+            [
+              %HopHint{
+                node_id: testHopHintPubkey3,
+                channel_id: 0x08FE4E000CF00001,
+                fee_base_m_sat: 1000,
+                fee_proportional_millionths: 2500,
+                cltv_expiry_delta: 40
+              }
+            ]
           ]
         }
       },

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -223,6 +223,48 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           min_final_cltv_expiry: 18
         }
       },
+      # real-world invoice with three r fields (three single-hop route hints)
+      {
+        "lnbc1p4ycf36pp5tg2m82kyfskhrgjdjerue486v5hhkrvz6nh8hgwh32s2n9t026dqdqlf35kw6r5de5kueeqv3jhqmmnd96zqvqcqzzsxqrrssrzjqw4t06fjwutwa9rt37l6uqumpku9x4j5neevtn9pz04x0zfapqs72r9kdyqqvcsqqyqqqqqqqqqqqqqq2qrzjqvphmsywntrrhqjcraumvc4y6r8v4z5v593trte429v4hredj7ms5rdxngqqgecqqyqqqqqqqqqqqqqq2qrzjqvphmsywntrrhqjcraumvc4y6r8v4z5v593trte429v4hredj7ms5rpeeqqqt9cqqyqqqqqqqqqqqqqq2qsp5yl9unpjreynlvuzmdq9z4ln700kufrk6lcsg2pe8cvzm0lu2alus9qxpqysgqzjkvm4js03nff029qlvk34hnw3g97nrkerllqrfehyqcwcwvps89y8q78qptjnn5kv28f62zkmvyj52u6ls6xeytxes630l0ke5qpccq8dd6nl",
+        %Invoice{
+          network: :mainnet,
+          destination: "0294774ee02a9faa5a5870061f7f4833686184ad14a0b163c49442516c9edac1db",
+          payment_hash: "5a15b3aac44c2d71a24d9647ccd4fa652f7b0d82d4ee7ba1d78aa0a9956f569a",
+          timestamp: 1_783_375_418,
+          description: "Lightning deposit 0",
+          expiry: 3600,
+          route_hints: [
+            [
+              %HopHint{
+                node_id: "03aab7e9327716ee946b8fbfae039b0db85356549e72c5cca113ea67893d0821e5",
+                channel_id: 0x0CB6690006620001,
+                fee_base_m_sat: 0,
+                fee_proportional_millionths: 0,
+                cltv_expiry_delta: 80
+              }
+            ],
+            [
+              %HopHint{
+                node_id: "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
+                channel_id: 0x0DA69A0004670001,
+                fee_base_m_sat: 0,
+                fee_proportional_millionths: 0,
+                cltv_expiry_delta: 80
+              }
+            ],
+            [
+              %HopHint{
+                node_id: "03037dc08e9ac63b82581f79b662a4d0ceca8a8ca162b1af3551595b8f2d97b70a",
+                channel_id: 0x0C39C80005970001,
+                fee_base_m_sat: 0,
+                fee_proportional_millionths: 0,
+                cltv_expiry_delta: 80
+              }
+            ]
+          ],
+          min_final_cltv_expiry: 80
+        }
+      },
       # On mainnet, with fallback (p2sh) address 3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX
       {
         "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfppj3a24vwu6r8ejrss3axul8rxldph2q7z9kk822r8plup77n9yq5ep2dfpcydrjwzxs0la84v3tfw43t3vqhek7f05m6uf8lmfkjn7zv7enn76sq65d8u9lxav2pl6x3xnc2ww3lqpagnh0u",

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -281,6 +281,20 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
           min_final_cltv_expiry: 18
         }
       },
+      # an empty f field (no version byte at all) is skipped rather than
+      # failing the decode, leaving no fallback addresses
+      {
+        "lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfqqepvrhrm9s57hejg0p662ur5j5cr03890fa7k2pypgttmh4897d3raaq85a293e9jpuqwl0rnfuwzam7yr8e690nd2ypcq9hlkdwdvycqjhlqg5",
+        %Invoice{
+          network: :mainnet,
+          destination: "02700c59a993fbb71ed906159f562f86b73219f97a18de2c65b62bfd0748d5821a",
+          payment_hash: test_payment_hash,
+          amount_msat: 2_000_000_000,
+          timestamp: 1_496_314_658,
+          description_hash: test_description_hash_slice,
+          min_final_cltv_expiry: 18
+        }
+      },
       # three f fields: P2PKH, then one with an unknown version (19, skipped),
       # then P2WPKH. All known-version fallback addresses are collected in order.
       {
@@ -564,8 +578,6 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
       "lnbcm1aaamcu25m",
       # invalid amount
       "lnbc1000000000m1",
-      # empty fallback address field
-      "lnbc20m1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfqqepvrhrm9s57hejg0p662ur5j5cr03890fa7k2pypgttmh4897d3raaq85a293e9jpuqwl0rnfuwzam7yr8e690nd2ypcq9hlkdwdvycqjhlqg5",
       # invalid routing info length: not a multiple of 51
       "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frqg00000000j9n4evl6mr5aj9f58zp6fyjzup6ywn3x6sk8akg5v4tgn2q8g4fhx05wf6juaxu9760yp46454gpg5mtzgerlzezqcqvjnhjh8z3g2qqsj5cgu",
       # no payment hash set


### PR DESCRIPTION
## Problem

BOLT#11 allows an invoice to carry **multiple `r` (route hint) fields** — each one a complete private route of one or more hops:

> **`r` (3):** `data_length` variable. One or more entries containing extra routing information for a private route; there may be more than one `r` field

Our decoder only kept the first `r` field: `parse_tagged_field/4` guarded every field with `Map.has_key?(acc, ...)`, which is correct for singleton fields like `p`/`d`/`h`, but silently dropped every `r` field after the first. In practice this loses route hints on invoices from nodes with multiple private channels (e.g. lnd emits one `r` field per hint).

The same applied to **`f` (fallback address) fields**, which BOLT#11 also allows more than one of ("MAY include one or more `f` fields", most-preferred first). Worse, an `f` field with an unknown version stored `nil` under the guard key, blocking later valid `f` fields — violating the reader requirement to "skip over `f` fields that use an unknown `version`".

## Fix

- Type-3 fields now **accumulate**: each `r` field is parsed into a route hint (a list of `HopHint`s) and appended to `route_hints` in encounter order.
- `Invoice.route_hints` is now `list(list(HopHint.t()))` — a list of route hints, each a list of hops. This matches the spec and other implementations (lnd's `RouteHints [][]HopHint`, rust-lightning's `Vec<RouteHint>`).
- **Empty `r` fields are skipped**: BOLT#11 requires each `r` field to contain "one or more entries", so a zero-hop `r` field is invalid; we skip it rather than emit an empty route or fail the decode.
- Type-9 fields now accumulate too: all known-version fallback addresses are collected as `Invoice.fallback_addresses` (a list, most-preferred first), and unknown-version `f` fields are skipped without blocking later ones.
- **Removed the lnd-specific 20-route-hint limit** (`{:error, :too_many_private_routes}`): BOLT#11 places no limit on the number of `r` fields, so invoices with more than 20 route hints now decode successfully.

> ⚠️ **Breaking changes** (noted in the CHANGELOG under Unreleased):
> - `Invoice.route_hints` elements are now routes (`[HopHint.t()]`) rather than bare `HopHint`s.
> - `Invoice.fallback_address` (single address or `nil`) is replaced by `Invoice.fallback_addresses` (`[String.t()]`, empty if none).
> - Invoices with more than 20 route hints no longer fail with `:too_many_private_routes`.

## Tests

- Existing route-hint vectors updated to the nested shape; existing fallback vectors updated to the list shape.
- Added a vector with **two `r` fields** (built from the spec's 1-hophint vector, re-signed with the BOLT#11 spec test key `e126f6...b734`).
- Added a real-world vector with **three `r` fields**.
- Added a vector with a trailing **empty `r` field** (skipped; route hints preserved).
- Added a vector with **three `f` fields** — P2PKH, unknown version 19 (skipped), P2WPKH — asserting both known-version addresses are collected in order.
- Added a vector with **21 `r` fields** asserting all 21 route hints decode.

`mix test` (179 tests, 0 failures) and `mix lint.all` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
