### PR TITLE
Bound invoice length; validate P2PKH/P2SH fallback hash length; drop dead decode clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- BOLT11 invoice decoding now rejects invoices longer than 7089 characters with `{:error, :overall_max_length_exceeded}`, matching rust-lightning's limit (the capacity of the largest QR code). This bounds the work done decoding untrusted input now that all `r` (route hint) and `f` (fallback address) fields are parsed.
 ### Fixed
 - BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped.
 - BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version and empty `f` fields without blocking later valid ones or failing the decode. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - BOLT11 invoice decoding now parses all `r` (route hint) fields instead of only the first. **Breaking:** `Invoice.route_hints` is now a list of route hints, each a list of `HopHint`s (`list(list(HopHint.t()))`), matching the BOLT11 spec where each `r` field is a separate private route. Empty `r` fields (invalid per BOLT11, which requires "one or more entries") are skipped.
 - BOLT11 invoice decoding now parses all `f` (fallback address) fields instead of only the first, and correctly skips unknown-version and empty `f` fields without blocking later valid ones or failing the decode. **Breaking:** `Invoice.fallback_address` (a single address or `nil`) is replaced by `Invoice.fallback_addresses`, a list of addresses in order of preference (empty if none).
+- BOLT11 `f` (fallback address) fields with version 17 (P2PKH) or 18 (P2SH) now require a 20-byte hash payload; any other length fails the decode with `:invalid_pubkey_hash_length` / `:invalid_script_hash_length` instead of encoding a garbage address.
+- Removed an unreachable `Invoice.decode/1` clause that shadowed the `{:error, :no_ln_prefix}` error; the error is (and was) returned by HRP parsing inside the main clause, so behavior is unchanged.
 ### Removed
 - The lnd-specific limit of 20 route hints per invoice (`{:error, :too_many_private_routes}`). BOLT11 places no limit on the number of `r` fields, so invoices with more than 20 route hints now decode successfully.
 

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -57,18 +57,22 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   @sha256_hash_base32_length 52
   @pubkey_base32_length 53
   @hop_hint_length 51
+  # BOLT#11 places no upper bound on invoice length (it lifts BIP-173's
+  # 90-character limit), but decoding untrusted input must be bounded, so we
+  # match rust-lightning's limit: 7089 characters, the capacity of the
+  # largest QR code (version 40, numeric mode, error-correction level L).
+  @max_invoice_length 7089
   @type error :: atom
 
   @doc """
    Decode accepts a Bech32 encoded string invoice and deserializes it.
 
-   BOLT#11 places no upper bound on invoice length (it lifts BIP-173's
-   90-character limit), so no size limit is enforced here; callers decoding
-   untrusted input should bound the string length themselves.
+   Invoices longer than #{@max_invoice_length} characters (the capacity of
+   the largest QR code) are rejected with `{:error, :overall_max_length_exceeded}`.
   """
   @spec decode(String.t()) :: {:ok, t} | {:error, error}
   def decode(invoice) when is_binary(invoice) do
-    with {:ok, {_encoding_type, hrp, data}} <- Bech32.decode(invoice, :infinity),
+    with {:ok, {_encoding_type, hrp, data}} <- Bech32.decode(invoice, @max_invoice_length),
          {:ok, {network, amount_msat}} <- parse_hrp(hrp),
          {invoice_data, signature_data} = split_at(data, -@signature_base32_length),
          {:ok, parsed_data} <-

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -407,10 +407,10 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       17 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
           # a P2PKH fallback address must carry a 20-byte pubkey hash
-          {:ok, pubKeyHash} when length(pubKeyHash) == 20 ->
+          {:ok, pub_key_hash} when length(pub_key_hash) == 20 ->
             {:ok,
              Bitcoinex.Address.encode(
-               pubKeyHash |> :binary.list_to_bin(),
+               pub_key_hash |> :binary.list_to_bin(),
                network,
                :p2pkh
              )}
@@ -425,10 +425,10 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
       18 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
           # a P2SH fallback address must carry a 20-byte script hash
-          {:ok, scriptHash} when length(scriptHash) == 20 ->
+          {:ok, script_hash} when length(script_hash) == 20 ->
             {:ok,
              Bitcoinex.Address.encode(
-               scriptHash |> :binary.list_to_bin(),
+               script_hash |> :binary.list_to_bin(),
                network,
                :p2sh
              )}

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -95,10 +95,6 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     end
   end
 
-  def decode(invoice) when is_binary(invoice) do
-    {:error, :no_ln_prefix}
-  end
-
   @doc """
    Returns the expiry of the invoice.
   """
@@ -410,7 +406,8 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
 
       17 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
-          {:ok, pubKeyHash} ->
+          # a P2PKH fallback address must carry a 20-byte pubkey hash
+          {:ok, pubKeyHash} when length(pubKeyHash) == 20 ->
             {:ok,
              Bitcoinex.Address.encode(
                pubKeyHash |> :binary.list_to_bin(),
@@ -418,19 +415,26 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
                :p2pkh
              )}
 
+          {:ok, _} ->
+            {:error, :invalid_pubkey_hash_length}
+
           err ->
             err
         end
 
       18 ->
         case Bech32.convert_bits(rest, 5, 8, false) do
-          {:ok, scriptHash} ->
+          # a P2SH fallback address must carry a 20-byte script hash
+          {:ok, scriptHash} when length(scriptHash) == 20 ->
             {:ok,
              Bitcoinex.Address.encode(
                scriptHash |> :binary.list_to_bin(),
                network,
                :p2sh
              )}
+
+          {:ok, _} ->
+            {:error, :invalid_script_hash_length}
 
           err ->
             err

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -690,6 +690,27 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
       assert {:error, :invalid_witness_program_length} = Invoice.decode(invoice)
     end
 
+    test "fail to decode when an f field hash payload has the wrong length" do
+      # the 1-hophint test vector with an extra f field appended carrying a
+      # 5-byte payload (P2PKH pubkey hashes and P2SH script hashes must be
+      # 20 bytes). (Tagged fields are parsed before signature verification,
+      # so the spliced-in field doesn't require re-signing.)
+      version_17_invoice =
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvfqf3rrrrrrrrncsk57n4v9ehw86wq8fzvjejhv9z3w3q5zh6qkql005x9xl240ch23jk79ujzvr4hsmmafyxghpqe79psktnjl668ntaf4ne7ucs5csqsq58rs"
+
+      assert {:error, :invalid_pubkey_hash_length} = Invoice.decode(version_17_invoice)
+
+      version_18_invoice =
+        "lnbc20m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85frzjq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqqqqqqq9qqqvfqfjrrrrrrrrncsk57n4v9ehw86wq8fzvjejhv9z3w3q5zh6qkql005x9xl240ch23jk79ujzvr4hsmmafyxghpqe79psktnjl668ntaf4ne7ucs5csqjj9mew"
+
+      assert {:error, :invalid_script_hash_length} = Invoice.decode(version_18_invoice)
+    end
+
+    test "fail to decode a bech32 string without the ln prefix" do
+      assert {:error, :no_ln_prefix} =
+               Invoice.decode("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+    end
+
     test "fail to decode with invalid segwit addresses in mainnet", %{
       invalid_encoded_invoices: invalid_encoded_invoices
     } do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -706,6 +706,16 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
       assert {:error, :invalid_script_hash_length} = Invoice.decode(version_18_invoice)
     end
 
+    test "fail to decode an invoice longer than 7089 characters" do
+      # 7089 is the capacity of the largest QR code (version 40, numeric
+      # mode, ECC level L), matching rust-lightning's invoice length limit.
+      # The length check runs before any parsing, so the content past the
+      # prefix doesn't matter.
+      invoice = "lnbc20m1" <> String.duplicate("q", 7082)
+      assert String.length(invoice) == 7090
+      assert {:error, :overall_max_length_exceeded} = Invoice.decode(invoice)
+    end
+
     test "fail to decode a bech32 string without the ln prefix" do
       assert {:error, :no_ln_prefix} =
                Invoice.decode("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")


### PR DESCRIPTION
Fixes two pre-existing bugs in BOLT11 invoice decoding surfaced while reviewing #114, and bounds the size of decoded invoices.

## Missing length validation for version 17/18 fallback addresses

`parse_fallback_address/2` checked the witness program length for version 0 (`:invalid_witness_program_length` unless 20 or 32 bytes), but versions 17 (P2PKH) and 18 (P2SH) accepted a payload of **any** length and Base58Check-encoded it into a syntactically valid-looking but garbage address. An invoice with a version-17 `f` field carrying e.g. a 5-byte payload decoded "successfully" with a bogus fallback address that no wallet could pay to.

Both versions now require the 20-byte hash160; anything else fails the decode with `:invalid_pubkey_hash_length` / `:invalid_script_hash_length`, consistent with the version-0 handling and with the strictness locked in by #114 for malformed known-version fields.

## Unreachable `decode/1` clause

The second `decode/1` clause repeated the first clause's `when is_binary(invoice)` guard, so its `{:error, :no_ln_prefix}` body was unreachable dead code (dates to 2019). The error is (and was) actually produced by `parse_hrp/1` inside the main clause's `with` chain, so deleting the clause changes no behavior — a non-`ln` bech32 string still returns `{:error, :no_ln_prefix}`, and non-binary input still raises `FunctionClauseError` (a programmer error per the `String.t()` spec).

## Maximum invoice length of 7089 characters

`decode/1` previously called `Bech32.decode(invoice, :infinity)`, leaving the work done on untrusted input unbounded — riskier now that #114 parses every `r` and `f` field. Decoding now rejects invoices longer than **7089 characters** with `{:error, :overall_max_length_exceeded}`, adopting rust-lightning's limit: 7089 is the capacity of the largest QR code (version 40, numeric mode, ECC level L), so any interop-relevant invoice still decodes while adversarial multi-megabyte strings are rejected before any parsing.

## Tests

- Vectors with version-17 and version-18 `f` fields carrying 5-byte payloads, asserting the new error atoms (spliced into the spec's 1-hophint vector; tagged fields are parsed before signature verification, so no re-signing is needed).
- A test asserting a valid bech32 string without the `ln` prefix returns `{:error, :no_ln_prefix}`.
- A test asserting a 7090-character invoice fails with `:overall_max_length_exceeded` (the 21-route-hint vector from #114, ~2.2k chars, still decodes).

`mix test` (184 tests, 0 failures) and `mix lint.all` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
