### PR TITLE
S2 follow-up: BIP-39 review findings (S1–S3 doc/spec)

### DIFF
--- a/lib/bip39.ex
+++ b/lib/bip39.ex
@@ -94,8 +94,12 @@ defmodule Bitcoinex.BIP39 do
     Per BIP-39, seed derivation accepts any string, so the checksum is
     not validated here. Use `valid?/1` or `to_master_private_key/3` when
     validation is required.
+
+    Unlike the other functions in this module, which return result tuples,
+    this raises `ArgumentError` if the mnemonic or passphrase is not valid
+    UTF-8 (NFKD normalization is undefined otherwise).
   """
-  @spec to_seed(String.t(), binary) :: binary
+  @spec to_seed(String.t(), String.t()) :: binary
   def to_seed(mnemonic, passphrase \\ "") when is_binary(mnemonic) and is_binary(passphrase) do
     Utils.pbkdf2(
       :sha512,
@@ -111,9 +115,11 @@ defmodule Bitcoinex.BIP39 do
     from a mnemonic sentence and an optional passphrase. The mnemonic's
     checksum is validated before derivation.
   """
+  # Intentionally mirrors the private-key prefixes ExtendedKey supports; a new
+  # prv prefix must be added here too, otherwise it is rejected before derivation.
   @prv_prefix_atoms [:xprv, :tprv]
 
-  @spec to_master_private_key(String.t(), binary, atom) ::
+  @spec to_master_private_key(String.t(), String.t(), atom) ::
           {:ok, ExtendedKey.t()} | {:error, error() | String.t()}
   def to_master_private_key(mnemonic, passphrase \\ "", prefix \\ :xprv)
       when is_binary(mnemonic) and is_binary(passphrase) do


### PR DESCRIPTION
Follow-up to the merged #109 (`S2: BIP-39`), addressing three doc/spec review findings. Doc/spec-only — no behavior change.

- **S1** `to_seed/2` — documents that it raises `ArgumentError` on non-UTF-8 input, unlike the result-tuple functions in the rest of the module.
- **S2** widens the passphrase spec type from `binary` to `String.t()` on `to_seed/2` and `to_master_private_key/3`, reflecting the valid-UTF-8 requirement enforced via `nfkd/1`.
- **S3** notes that `@prv_prefix_atoms` intentionally mirrors the private-key prefixes `ExtendedKey` supports (a new prv prefix must be added here too).

Verified: `mix test test/bip39_test.exs` (1 doctest, 4 properties, 20 tests) and `mix lint.all` both pass.

Base is `sachin--slip39-0-wordlists` (current stack integration branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
