### PR TITLE
Cut release: bitcoinex v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-08-04
 ### Added
 - `PSBT.finalize/1` and `PSBT.finalized?/1` (Input Finalizer): assembles `final_scriptsig`/`final_scriptwitness` from the collected signatures and scripts for p2pkh, p2wpkh, (nested) p2sh-p2wpkh, bare/p2sh/p2wsh multisig, and p2sh-p2wsh inputs, ordering multisig signatures by the script's pubkey order. Best-effort per input (matching Bitcoin Core): inputs it cannot finalize are left untouched — including any whose `redeem_script`/`witness_script` does not hash to the scriptPubKey/witness program or whose single-key signature's pubkey does not hash to the p2pkh/p2wpkh hash (the BIP-174 Signer script/key-hash checks), and any non-witness spend type (p2pkh, bare/p2sh legacy multisig) without a `non_witness_utxo` matching the input's outpoint — a `witness_utxo` alone cannot be verified and never steers a non-witness finalization. When an input specifies a `sighash_type`, only signatures carrying that flag are eligible for selection; signatures with other flags (e.g. contributed for unrelated keys by another signer) do not block finalization. `finalized?/1` is false for a PSBT with no inputs.
 - `PSBT.extract_tx/1` (Transaction Extractor): produces the fully-signed network `Transaction` from a finalized PSBT, or `{:error, :not_finalized}`.
@@ -95,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transaction module.
 
 
+[0.3.0]: https://diff.hex.pm/diff/bitcoinex/0.2.0..0.3.0
 [0.2.0]: https://diff.hex.pm/diff/bitcoinex/0.1.8..0.2.0
 [0.1.4]: https://diff.hex.pm/diff/bitcoinex/0.1.3..0.1.4
 [0.1.3]: https://diff.hex.pm/diff/bitcoinex/0.1.2..0.1.3

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Documentation is available on [hexdocs.pm](https://hexdocs.pm/bitcoinex/api-refe
 * Serialization and validation for Bech32 and Base58.
 * Support for standard on-chain scripts (P2PKH..P2WPKH) and Bolt#11 Lightning Invoices.
 * Transaction serialization.
-* Basic PSBT (BIP174) parsing.
+* PSBT (BIP174) v0 support: lossless (de)serialization plus the Creator, Updater, Combiner, Input Finalizer, and Transaction Extractor roles.
 
 ## Usage
 
 With [Hex](https://hex.pm/packages/bitcoinex):
 
-    {:bitcoinex, "~> 0.1.7"}
+    {:bitcoinex, "~> 0.3.0"}
 
 Local:
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bitcoinex.MixProject do
   def project do
     [
       app: :bitcoinex,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.11",
       package: package(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Prepares the 0.3.0 release. No library code changes — version metadata and docs only.

- `mix.exs`: `0.2.0` → `0.3.0`
- `CHANGELOG.md`: moves the accumulated `[Unreleased]` entries under `## [0.3.0] - 2026-08-04` and adds the `diff.hex.pm` link, matching how 0.2.0 was cut in 2499a14
- `README.md`: Hex dep snippet was still pinned to `~> 0.1.7` (stale since before 0.2.0) → `~> 0.3.0`; the "Basic PSBT (BIP174) parsing" bullet now describes the full v0 role support that landed in #118–#122

### Why minor, not patch

0.3.0 contains breaking changes, which pre-1.0 SemVer puts in the minor slot:

- decoded PSBT fields are typed `Bitcoinex` structs rather than hex/Base58 strings or integer lists
- `partial_sig` is a list of records (BIP-174 allows several per input) instead of a single map
- `PSBT.encode_b64/1` returns `{:ok, base64}` instead of a bare string
- `PSBT.Utils.parse_compact_size_value/1` returns `{:ok, value, remaining}` instead of `{value, remaining}`

### Verified locally

- `mix test` — 337 tests, 0 failures
- `mix lint.all` — format clean, credo 678 mods/funs, no issues
- `mix hex.build` — builds as `bitcoinex-0.3.0.tar` (155 KB)

### Publishing (not done here)

`mix hex.publish` still needs to be run by hand: `mix hex.user whoami` currently reports a failed token refresh, so it needs `mix hex.user auth` first, under a user with publish rights on the `riverfinancial` org that owns the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)