### PR TITLE
Reject out-of-range r,s in ECDSA signature parsing and verification

### DIFF
--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -123,10 +123,8 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
   """
   @spec verify_signature(Point.t(), integer, Signature.t()) :: boolean
   def verify_signature(pubkey, sighash, %Signature{r: r, s: s}) do
-    # r,s must be integers in [1, n-1]. This is enforced here as well as at
-    # parse time so that verification is safe even when handed a Signature
-    # struct built by other means: with r = s = 0, Math.inv(0, n) returns 0,
-    # making total the point at infinity, whose x is 0 and would match r.
+    # also checked at parse time; repeated here so verification does not depend
+    # on how the Signature was constructed
     if in_curve_order_range?(r) and in_curve_order_range?(s) do
       s_inv = Math.inv(s, @n)
       u = Math.modulo(sighash * s_inv, @n)

--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -125,7 +125,7 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
   def verify_signature(pubkey, sighash, %Signature{r: r, s: s}) do
     # also checked at parse time; repeated here so verification does not depend
     # on how the Signature was constructed
-    if in_curve_order_range?(r) and in_curve_order_range?(s) do
+    if Params.in_curve_order_range?(r) and Params.in_curve_order_range?(s) do
       s_inv = Math.inv(s, @n)
       u = Math.modulo(sighash * s_inv, @n)
       v = Math.modulo(r * s_inv, @n)
@@ -135,8 +135,6 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
       false
     end
   end
-
-  defp in_curve_order_range?(k), do: is_integer(k) and k >= 1 and k <= @n - 1
 
   @doc """
     ecdsa_recover_compact does ECDSA public key recovery.

--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -123,12 +123,22 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
   """
   @spec verify_signature(Point.t(), integer, Signature.t()) :: boolean
   def verify_signature(pubkey, sighash, %Signature{r: r, s: s}) do
-    s_inv = Math.inv(s, @n)
-    u = Math.modulo(sighash * s_inv, @n)
-    v = Math.modulo(r * s_inv, @n)
-    total = Math.add(Math.multiply(@generator_point, u), Math.multiply(pubkey, v))
-    total.x == r
+    # r,s must be integers in [1, n-1]. This is enforced here as well as at
+    # parse time so that verification is safe even when handed a Signature
+    # struct built by other means: with r = s = 0, Math.inv(0, n) returns 0,
+    # making total the point at infinity, whose x is 0 and would match r.
+    if in_curve_order_range?(r) and in_curve_order_range?(s) do
+      s_inv = Math.inv(s, @n)
+      u = Math.modulo(sighash * s_inv, @n)
+      v = Math.modulo(r * s_inv, @n)
+      total = Math.add(Math.multiply(@generator_point, u), Math.multiply(pubkey, v))
+      not Point.is_inf(total) and total.x == r
+    else
+      false
+    end
   end
+
+  defp in_curve_order_range?(k), do: is_integer(k) and k >= 1 and k <= @n - 1
 
   @doc """
     ecdsa_recover_compact does ECDSA public key recovery.

--- a/lib/secp256k1/params.ex
+++ b/lib/secp256k1/params.ex
@@ -23,4 +23,11 @@ defmodule Bitcoinex.Secp256k1.Params do
       h: 0x01
     }
   end
+
+  @doc """
+  Checks that k is a valid scalar in [1, n-1], where n is the curve order.
+  Signature components r and s must be in this range.
+  """
+  @spec in_curve_order_range?(term()) :: boolean()
+  def in_curve_order_range?(k), do: is_integer(k) and k >= 1 and k <= curve().n - 1
 end

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -87,10 +87,6 @@ defmodule Bitcoinex.Secp256k1 do
 
     defp parse_sig_key(_data), do: {:error, "invalid signature key marker"}
 
-    # Verify that r,s are integers in [1, n-1] where n is the integer order of G
-    # before building a Signature. Values outside that range are not just
-    # non-canonical, they are forgeable: r = s = 0 makes verification compare
-    # the point at infinity's x-coordinate (0) against r (0).
     defp new_signature(r, s) do
       if in_curve_order_range?(r) and in_curve_order_range?(s) do
         {:ok, %Signature{r: r, s: s}}

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -88,14 +88,12 @@ defmodule Bitcoinex.Secp256k1 do
     defp parse_sig_key(_data), do: {:error, "invalid signature key marker"}
 
     defp new_signature(r, s) do
-      if in_curve_order_range?(r) and in_curve_order_range?(s) do
+      if Params.in_curve_order_range?(r) and Params.in_curve_order_range?(s) do
         {:ok, %Signature{r: r, s: s}}
       else
         {:error, "invalid signature"}
       end
     end
-
-    defp in_curve_order_range?(k), do: k >= 1 and k <= Params.curve().n - 1
 
     @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s}) do

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -37,23 +37,7 @@ defmodule Bitcoinex.Secp256k1 do
       r = :binary.decode_unsigned(r)
       s = :binary.decode_unsigned(s)
 
-      # Verify that r,s are integers in [1, n-1] where n is the integer order of G.
-      cond do
-        r < 1 ->
-          {:error, "invalid signature"}
-
-        r > Params.curve().n - 1 ->
-          {:error, "invalid signature"}
-
-        s < 1 ->
-          {:error, "invalid signature"}
-
-        s > Params.curve().n - 1 ->
-          {:error, "invalid signature"}
-
-        true ->
-          {:ok, %Signature{r: r, s: s}}
-      end
+      new_signature(r, s)
     end
 
     # attempt to parse 64-byte string
@@ -80,7 +64,7 @@ defmodule Bitcoinex.Secp256k1 do
         with {:ok, r, rest} <- parse_sig_key(body),
              {:ok, s, rest} <- parse_sig_key(rest) do
           if rest == <<>> do
-            {:ok, %Signature{r: r, s: s}}
+            new_signature(r, s)
           else
             {:error, "invalid signature: signature is too long"}
           end
@@ -102,6 +86,20 @@ defmodule Bitcoinex.Secp256k1 do
     end
 
     defp parse_sig_key(_data), do: {:error, "invalid signature key marker"}
+
+    # Verify that r,s are integers in [1, n-1] where n is the integer order of G
+    # before building a Signature. Values outside that range are not just
+    # non-canonical, they are forgeable: r = s = 0 makes verification compare
+    # the point at infinity's x-coordinate (0) against r (0).
+    defp new_signature(r, s) do
+      if in_curve_order_range?(r) and in_curve_order_range?(s) do
+        {:ok, %Signature{r: r, s: s}}
+      else
+        {:error, "invalid signature"}
+      end
+    end
+
+    defp in_curve_order_range?(k), do: k >= 1 and k <= Params.curve().n - 1
 
     @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s}) do

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -3,7 +3,9 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
 
   doctest Bitcoinex.Secp256k1.Ecdsa
 
-  alias Bitcoinex.Secp256k1.{Ecdsa, Point, PrivateKey, Signature}
+  alias Bitcoinex.Secp256k1.{Ecdsa, Params, Point, PrivateKey, Signature}
+
+  @curve_order Params.curve().n
 
   @valid_signatures_for_public_key_recovery [
     %{
@@ -244,6 +246,70 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
         sig = Ecdsa.sign(t.privkey, z)
         assert sig == t.signature
         assert Ecdsa.verify_signature(t.pubkey, z, sig)
+      end
+    end
+  end
+
+  describe "verify_signature/3 rejections" do
+    setup do
+      t = hd(@valid_signature_pubkey_sighash_sets)
+      sighash = :binary.decode_unsigned(Bitcoinex.Utils.double_sha256(t.msg))
+      {:ok, pubkey: t.pubkey, sighash: sighash, sig: t.signature}
+    end
+
+    test "the reference vector verifies, so the refutations below are meaningful", %{
+      pubkey: pubkey,
+      sighash: sighash,
+      sig: sig
+    } do
+      assert Ecdsa.verify_signature(pubkey, sighash, sig)
+    end
+
+    test "reject a valid signature against the wrong message hash", %{
+      pubkey: pubkey,
+      sig: sig
+    } do
+      other_sighash = :binary.decode_unsigned(Bitcoinex.Utils.double_sha256("goodbye world"))
+      refute Ecdsa.verify_signature(pubkey, other_sighash, sig)
+    end
+
+    test "reject a valid signature against a different public key", %{
+      sighash: sighash,
+      sig: sig
+    } do
+      other_pubkey = PrivateKey.to_point(%PrivateKey{d: 987_654_321_098_765_432_109_876})
+      refute Ecdsa.verify_signature(other_pubkey, sighash, sig)
+    end
+
+    test "reject a signature with r tampered", %{pubkey: pubkey, sighash: sighash, sig: sig} do
+      refute Ecdsa.verify_signature(pubkey, sighash, %Signature{sig | r: sig.r + 1})
+    end
+
+    test "reject a signature with s tampered", %{pubkey: pubkey, sighash: sighash, sig: sig} do
+      refute Ecdsa.verify_signature(pubkey, sighash, %Signature{sig | s: sig.s + 1})
+    end
+
+    test "reject r = s = 0 built directly, bypassing the parser", %{
+      pubkey: pubkey,
+      sighash: sighash
+    } do
+      # This is the forgery: inv(0) = 0 zeroes both scalars, so the sum is the
+      # point at infinity (x = 0), which used to compare equal to r = 0 and made
+      # this signature verify against any pubkey and any sighash.
+      refute Ecdsa.verify_signature(pubkey, sighash, %Signature{r: 0, s: 0})
+      refute Ecdsa.verify_signature(pubkey, 0xDEADBEEF, %Signature{r: 0, s: 0})
+
+      other_pubkey = PrivateKey.to_point(%PrivateKey{d: 987_654_321_098_765_432_109_876})
+      refute Ecdsa.verify_signature(other_pubkey, sighash, %Signature{r: 0, s: 0})
+    end
+
+    test "reject r or s equal to 0, n, or n+1", %{pubkey: pubkey, sighash: sighash, sig: sig} do
+      for bad <- [0, @curve_order, @curve_order + 1] do
+        refute Ecdsa.verify_signature(pubkey, sighash, %Signature{sig | r: bad}),
+               "expected r = #{bad} to be rejected"
+
+        refute Ecdsa.verify_signature(pubkey, sighash, %Signature{sig | s: bad}),
+               "expected s = #{bad} to be rejected"
       end
     end
   end

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -257,7 +257,7 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       {:ok, pubkey: t.pubkey, sighash: sighash, sig: t.signature}
     end
 
-    test "the reference vector verifies, so the refutations below are meaningful", %{
+    test "the reference vector verifies", %{
       pubkey: pubkey,
       sighash: sighash,
       sig: sig
@@ -293,9 +293,6 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       pubkey: pubkey,
       sighash: sighash
     } do
-      # This is the forgery: inv(0) = 0 zeroes both scalars, so the sum is the
-      # point at infinity (x = 0), which used to compare equal to r = 0 and made
-      # this signature verify against any pubkey and any sighash.
       refute Ecdsa.verify_signature(pubkey, sighash, %Signature{r: 0, s: 0})
       refute Ecdsa.verify_signature(pubkey, 0xDEADBEEF, %Signature{r: 0, s: 0})
 

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -3,7 +3,10 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
   doctest Bitcoinex.Secp256k1
 
   alias Bitcoinex.Secp256k1
-  alias Bitcoinex.Secp256k1.{Signature}
+  alias Bitcoinex.Secp256k1.{Params, Signature}
+
+  # The integer order n of the generator point G, as a 32-byte big-endian hex string.
+  @curve_order_hex "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
 
   @valid_der_signatures [
     %{
@@ -103,6 +106,35 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
     }
   ]
 
+  # Structurally well-formed DER whose r or s falls outside the valid range
+  # [1, n-1]. Only the range check rejects these.
+  @out_of_range_der_signatures [
+    %{
+      # r = 0, s = 0. This 8-byte signature used to parse successfully and then
+      # verify against EVERY public key and EVERY sighash: inv(0) = 0 makes both
+      # scalars 0, so the resulting point is the point at infinity, represented
+      # as x = 0, which then compared equal to r = 0.
+      name: "r = 0, s = 0",
+      der_signature: Base.decode16!("3006020100020100", case: :upper)
+    },
+    %{
+      name: "r = 0",
+      der_signature: Base.decode16!("3006020100020101", case: :upper)
+    },
+    %{
+      name: "s = 0",
+      der_signature: Base.decode16!("3006020101020100", case: :upper)
+    },
+    %{
+      name: "r = n",
+      der_signature: Base.decode16!("3026022100" <> @curve_order_hex <> "020101", case: :upper)
+    },
+    %{
+      name: "s = n",
+      der_signature: Base.decode16!("3026020101022100" <> @curve_order_hex, case: :upper)
+    }
+  ]
+
   @valid_schnorr_signatures [
     "E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0",
     "6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A",
@@ -125,6 +157,24 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
       for t <- @invalid_der_signatures do
         assert {:error, _error} = Secp256k1.Signature.der_parse_signature(t.der_signature)
       end
+    end
+
+    test "reject r or s outside [1, n-1]" do
+      # guard against the test vectors drifting from the real curve order
+      assert :binary.decode_unsigned(Base.decode16!(@curve_order_hex, case: :upper)) ==
+               Params.curve().n
+
+      for t <- @out_of_range_der_signatures do
+        assert {:error, _error} = Secp256k1.Signature.der_parse_signature(t.der_signature),
+               "expected #{t.name} to be rejected"
+      end
+    end
+
+    test "reject the all-zero r,s forgery signature" do
+      assert {:error, _error} =
+               Secp256k1.Signature.der_parse_signature(
+                 <<0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x00>>
+               )
     end
   end
 

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -5,7 +5,6 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
   alias Bitcoinex.Secp256k1
   alias Bitcoinex.Secp256k1.{Params, Signature}
 
-  # The integer order n of the generator point G, as a 32-byte big-endian hex string.
   @curve_order_hex "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
 
   @valid_der_signatures [
@@ -106,14 +105,9 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
     }
   ]
 
-  # Structurally well-formed DER whose r or s falls outside the valid range
-  # [1, n-1]. Only the range check rejects these.
+  # well-formed DER whose r or s is outside [1, n-1]
   @out_of_range_der_signatures [
     %{
-      # r = 0, s = 0. This 8-byte signature used to parse successfully and then
-      # verify against EVERY public key and EVERY sighash: inv(0) = 0 makes both
-      # scalars 0, so the resulting point is the point at infinity, represented
-      # as x = 0, which then compared equal to r = 0.
       name: "r = 0, s = 0",
       der_signature: Base.decode16!("3006020100020100", case: :upper)
     },
@@ -160,7 +154,6 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
     end
 
     test "reject r or s outside [1, n-1]" do
-      # guard against the test vectors drifting from the real curve order
       assert :binary.decode_unsigned(Base.decode16!(@curve_order_hex, case: :upper)) ==
                Params.curve().n
 


### PR DESCRIPTION
## The bug

The 8-byte DER signature `3006020100020100` — that is, `r = 0, s = 0` — parsed successfully and then **verified against every public key and every message hash**. Any signature check built on `Ecdsa.verify_signature/3` could be bypassed with a fixed 8-byte constant.

Repro against `master`:

```elixir
{:ok, sig} = Bitcoinex.Secp256k1.Signature.der_parse_signature(<<0x30,0x06,0x02,0x01,0x00,0x02,0x01,0x00>>)
{:ok, sk} = Bitcoinex.Secp256k1.PrivateKey.new(0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF)
pk = Bitcoinex.Secp256k1.PrivateKey.to_point(sk)
Bitcoinex.Secp256k1.Ecdsa.verify_signature(pk, 0xDEADBEEF, sig)
#=> true
```

## Mechanism

`Signature.der_parse_signature/1` performed no range check on `r` and `s`, unlike its sibling `parse_signature/1`, which correctly enforces `1 <= r,s <= n-1`. `Ecdsa.verify_signature/3` validated nothing either. And `Math.inv(0, n)` returns `0` rather than failing.

So with `r = s = 0`: `s_inv = 0`, hence `u = v = 0`, hence `total = 0*G + 0*P` is the point at infinity, which `Math.fromJacobian` represents as `%Point{x: 0, y: 0}`. The final comparison `total.x == r` becomes `0 == 0` → `true`.

## The fix — applied at both layers, deliberately

1. **Parse** (`lib/secp256k1/secp256k1.ex`): `der_parse_signature/1` now rejects `r` or `s` outside `[1, n-1]` with `{:error, "invalid signature"}`. The range check lives in one shared public helper, `Params.in_curve_order_range?/1`, also used by `parse_signature/1`; both functions keep their existing return shapes and error strings.
2. **Verify** (`lib/secp256k1/ecdsa.ex`): `verify_signature/3` independently returns `false` for out-of-range `r`/`s`, and rejects the point at infinity via `Point.is_inf/1` before comparing `total.x == r`. The `:: boolean` contract is unchanged — no error tuples.

Fixing only the parser would leave verification unsafe for any `Signature` struct built by other means (constructed directly, decoded elsewhere, or reached through a future code path). Verification must not depend on its caller having parsed strictly, so both halves are in.

## Tests

**No negative verification test existed anywhere in the suite before this PR** — `verify_signature/3` was only ever asserted *true*, so a stub `def verify_signature(_,_,_), do: true` would have passed the entire existing test suite. That is precisely why this shipped. Added:

- `test/secp256k1/secp256k1_test.exs`: DER range rejection for `r = 0`, `s = 0`, `r = n`, `s = n`, plus a dedicated regression test for the `3006020100020100` vector. The `r = n` / `s = n` vectors are cross-checked against `Params.curve().n` so they cannot silently drift.
- `test/secp256k1/ecdsa_test.exs`: a new `verify_signature/3 rejections` block with `refute` cases for a valid signature against the wrong message hash, against a different public key, with `r` tampered, with `s` tampered, `%Signature{r: 0, s: 0}` constructed directly (bypassing the parser, so it exercises the verify-layer guard), and `r`/`s` set to `0`, `n`, and `n+1`. It also re-asserts that the reference vector still verifies, so the refutations are meaningful.

No existing assertion was weakened.

## Compatibility

`lib/psbt.ex` uses `der_parse_signature` as the validity gate for `PSBT_IN_PARTIAL_SIG`, and the PSBT suite round-trips non-canonical DER verbatim. Confirmed no interaction: the Bitcoin Core PSBT vectors contain no zero-valued or out-of-range `r`/`s`, and the full suite is green (346 tests, 0 failures — 337 before, 9 added). `sign/2`, `deterministic_k/2`, and `ecdsa_recover_compact/3` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

