### PR TITLE
Use the standard Bitcoin signed-message preimage in sign_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Secp256k1.Ecdsa.message_digest/1` returns the 32-byte digest of the standard Bitcoin signed-message preimage (`compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(byte_size(msg)) || msg`, double-SHA256).
+- `Secp256k1.Ecdsa.verify_message/3` verifies a signed message against a public key via public key recovery, accepting signatures produced by `sign_message/2` as well as by other wallets (Bitcoin Core, Electrum, etc.).
+### Fixed
+- **Breaking:** `Secp256k1.Ecdsa.sign_message/2` now signs the standard Bitcoin signed-message digest. It previously hashed `"Bitcoin Signed Message:\n" <> msg` without either CompactSize length prefix, so its signatures could not be verified by Bitcoin Core, Electrum, or any other wallet (and theirs could not be verified against its digest). Signatures produced by the old implementation will not verify against the new digest.
 
 ## [0.3.0] - 2026-08-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `Secp256k1.Ecdsa.message_digest/1` returns the 32-byte digest of the standard Bitcoin signed-message preimage (`compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(byte_size(msg)) || msg`, double-SHA256).
-- `Secp256k1.Ecdsa.verify_message/3` verifies a signed message against a public key via public key recovery, accepting signatures produced by `sign_message/2` as well as by other wallets (Bitcoin Core, Electrum, etc.).
+- `Secp256k1.Ecdsa.message_digest/1` and `Secp256k1.Ecdsa.verify_message/3`.
 ### Fixed
-- **Breaking:** `Secp256k1.Ecdsa.sign_message/2` now signs the standard Bitcoin signed-message digest. It previously hashed `"Bitcoin Signed Message:\n" <> msg` without either CompactSize length prefix, so its signatures could not be verified by Bitcoin Core, Electrum, or any other wallet (and theirs could not be verified against its digest). Signatures produced by the old implementation will not verify against the new digest.
+- **Breaking:** `Secp256k1.Ecdsa.sign_message/2` now signs the standard Bitcoin signed-message digest (`compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(len) || msg`, double-SHA256). It previously omitted both CompactSize length prefixes, so its signatures were not verifiable by any other wallet. Signatures made with the old digest will not verify.
 
 ## [0.3.0] - 2026-08-04
 ### Added

--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -104,13 +104,10 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
   @signed_message_magic "Bitcoin Signed Message:\n"
 
   @doc """
-  message_digest returns the 32-byte digest used by the standard Bitcoin
-  signed-message scheme (Bitcoin Core `signmessage`, Electrum, etc.).
-  The preimage is:
+  message_digest returns the double-SHA256 of the standard Bitcoin
+  signed-message preimage, as used by Bitcoin Core `signmessage` and Electrum:
 
       compact_size(24) || "Bitcoin Signed Message:\\n" || compact_size(byte_size(msg)) || msg
-
-  and the digest is the double-SHA256 of that preimage.
   """
   @spec message_digest(binary) :: binary
   def message_digest(msg) when is_binary(msg) do
@@ -124,11 +121,8 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
     do: Bitcoinex.Transaction.Utils.serialize_compact_size_unsigned_int(len)
 
   @doc """
-  sign_message returns an ECDSA signature over the standard Bitcoin
-  signed-message digest of msg (see message_digest/1), where privkey is a
-  PrivateKey object and msg is a binary message. The nonce is derived using
-  RFC6979, so the resulting signature is compatible with (and verifiable by)
-  Bitcoin Core, Electrum, and other wallets.
+  sign_message returns an ECDSA signature over message_digest/1 of msg, with
+  the nonce derived using RFC6979.
   """
   @spec sign_message(PrivateKey.t(), binary) :: Signature.t()
   def sign_message(privkey, msg) do
@@ -141,15 +135,16 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
   end
 
   @doc """
-  verify_message verifies that signature is a valid Bitcoin signed-message
-  signature by pubkey over msg (see message_digest/1). Verification is
-  performed via public key recovery, so it accepts signatures produced by
-  sign_message/2 as well as by other wallets (Bitcoin Core, Electrum, etc.).
+  verify_message verifies signature over message_digest/1 of msg by recovering
+  the public key and comparing it to pubkey.
   """
   @spec verify_message(Point.t(), binary, Signature.t()) :: boolean
   def verify_message(%Point{} = pubkey, msg, %Signature{} = signature) do
     digest = message_digest(msg)
-    compact_sig = Signature.serialize_signature(signature)
+    # r and s must each occupy exactly 32 bytes for recovery to parse them
+    compact_sig =
+      Bitcoinex.Utils.int_to_big(signature.r, 32) <> Bitcoinex.Utils.int_to_big(signature.s, 32)
+
     pubkey_hex = Point.serialize_public_key(pubkey)
 
     Enum.any?(0..3, fn recovery_id ->

--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -101,20 +101,63 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
     end
   end
 
+  @signed_message_magic "Bitcoin Signed Message:\n"
+
   @doc """
-  sign_message returns an ECDSA signature using the privkey and "Bitcoin Signed Message: <msg>"
-  where privkey is a PrivateKey object and msg is a binary message to be hashed.
-  The message is hashed using hash256 (double SHA256) and the nonce is derived
-  using RFC6979.
+  message_digest returns the 32-byte digest used by the standard Bitcoin
+  signed-message scheme (Bitcoin Core `signmessage`, Electrum, etc.).
+  The preimage is:
+
+      compact_size(24) || "Bitcoin Signed Message:\\n" || compact_size(byte_size(msg)) || msg
+
+  and the digest is the double-SHA256 of that preimage.
+  """
+  @spec message_digest(binary) :: binary
+  def message_digest(msg) when is_binary(msg) do
+    Bitcoinex.Utils.double_sha256(
+      compact_size(byte_size(@signed_message_magic)) <>
+        @signed_message_magic <> compact_size(byte_size(msg)) <> msg
+    )
+  end
+
+  defp compact_size(len),
+    do: Bitcoinex.Transaction.Utils.serialize_compact_size_unsigned_int(len)
+
+  @doc """
+  sign_message returns an ECDSA signature over the standard Bitcoin
+  signed-message digest of msg (see message_digest/1), where privkey is a
+  PrivateKey object and msg is a binary message. The nonce is derived using
+  RFC6979, so the resulting signature is compatible with (and verifiable by)
+  Bitcoin Core, Electrum, and other wallets.
   """
   @spec sign_message(PrivateKey.t(), binary) :: Signature.t()
   def sign_message(privkey, msg) do
     z =
-      ("Bitcoin Signed Message:\n" <> msg)
-      |> Bitcoinex.Utils.double_sha256()
+      msg
+      |> message_digest()
       |> :binary.decode_unsigned()
 
     sign(privkey, z)
+  end
+
+  @doc """
+  verify_message verifies that signature is a valid Bitcoin signed-message
+  signature by pubkey over msg (see message_digest/1). Verification is
+  performed via public key recovery, so it accepts signatures produced by
+  sign_message/2 as well as by other wallets (Bitcoin Core, Electrum, etc.).
+  """
+  @spec verify_message(Point.t(), binary, Signature.t()) :: boolean
+  def verify_message(%Point{} = pubkey, msg, %Signature{} = signature) do
+    digest = message_digest(msg)
+    compact_sig = Signature.serialize_signature(signature)
+    pubkey_hex = Point.serialize_public_key(pubkey)
+
+    Enum.any?(0..3, fn recovery_id ->
+      case ecdsa_recover_compact(digest, compact_sig, recovery_id) do
+        {:ok, recovered_pubkey} -> recovered_pubkey == pubkey_hex
+        {:error, _} -> false
+      end
+    end)
   end
 
   @doc """

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -247,4 +247,164 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       end
     end
   end
+
+  # digests independently derived from the standard preimage
+  # compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(byte_size(msg)) || msg
+  # and cross-checked with Python hashlib.
+  @message_digest_test_cases [
+    %{
+      # empty message: msg length compact_size is a single 0x00 byte
+      msg: "",
+      digest: "80e795d4a4caadd7047af389d9f7f220562feb6196032e2131e10563352c4bcc"
+    },
+    %{
+      msg: "hello",
+      digest: "cf0447ec85f0ce7150a257db32ebfcb7523dae17c36dbd1be598779fec0484f4"
+    },
+    %{
+      # 300 bytes: msg length compact_size takes the 0xFD two-byte form (fd2c01)
+      msg: String.duplicate("a", 300),
+      digest: "3ec158a43b80359df647352dac1d37dbf26a94e5f06e5790760290c75cd11dc0"
+    }
+  ]
+
+  describe "message_digest/1" do
+    test "matches the standard Bitcoin signed-message digest" do
+      for t <- @message_digest_test_cases do
+        assert Base.encode16(Ecdsa.message_digest(t.msg), case: :lower) == t.digest
+      end
+    end
+
+    test "is not the legacy unprefixed double_sha256 digest" do
+      for t <- @message_digest_test_cases do
+        old_digest = Bitcoinex.Utils.double_sha256("Bitcoin Signed Message:\n" <> t.msg)
+        refute Ecdsa.message_digest(t.msg) == old_digest
+      end
+    end
+  end
+
+  describe "sign_message/2" do
+    setup do
+      privkey = %PrivateKey{d: 123_414_253_234_542_345_423_623}
+      pubkey = PrivateKey.to_point(privkey)
+      {:ok, privkey: privkey, pubkey: pubkey}
+    end
+
+    test "sign then recover pubkey from message digest", %{privkey: privkey, pubkey: pubkey} do
+      pubkey_hex = Point.serialize_public_key(pubkey)
+
+      for msg <- ["", "hello", "hello world", String.duplicate("a", 300)] do
+        sig = Ecdsa.sign_message(privkey, msg)
+        digest = Ecdsa.message_digest(msg)
+        compact_sig = Signature.serialize_signature(sig)
+
+        recovered =
+          Enum.find_value(0..3, fn recovery_id ->
+            case Ecdsa.ecdsa_recover_compact(digest, compact_sig, recovery_id) do
+              {:ok, ^pubkey_hex} -> pubkey_hex
+              _ -> nil
+            end
+          end)
+
+        assert recovered == pubkey_hex
+      end
+    end
+
+    test "reproduces a Bitcoin Core signmessage signature byte for byte" do
+      # Vector from Bitcoin Core test/functional/rpc_signmessage.py:
+      #   priv_key = cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N (testnet WIF)
+      #   address  = mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB
+      #   message  = "This is just a test message"
+      #   expected_signature =
+      #     "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
+      privkey = %PrivateKey{
+        d: 0xD2B8A0116D641FE7D3036F8464628FB595B480414C13A301B3D4038C811C28B0
+      }
+
+      msg = "This is just a test message"
+
+      expected_sig =
+        Base.decode64!(
+          "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
+        )
+
+      # header byte 0x20 = 27 + recovery_id 1 + 4 (compressed pubkey)
+      <<0x20, r::binary-size(32), s::binary-size(32)>> = expected_sig
+
+      sig = Ecdsa.sign_message(privkey, msg)
+      assert sig.r == :binary.decode_unsigned(r)
+      assert sig.s == :binary.decode_unsigned(s)
+    end
+
+    test "recovers Bitcoin Core's pubkey from its signature" do
+      # Same Bitcoin Core vector as above, verified via pubkey recovery: the
+      # WIF private key derives pubkey 03c150..., which hash160s to address
+      # mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB.
+      msg = "This is just a test message"
+
+      expected_sig =
+        Base.decode64!(
+          "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
+        )
+
+      <<header, compact_sig::binary-size(64)>> = expected_sig
+      # recovery_id = header - 27 - 4 (compressed)
+      recovery_id = header - 31
+
+      assert {:ok, "03c150061989643d77162902b725409087959f15914649d4f06b6cc3f8c87bb238"} ==
+               Ecdsa.ecdsa_recover_compact(Ecdsa.message_digest(msg), compact_sig, recovery_id)
+    end
+  end
+
+  describe "verify_message/3" do
+    setup do
+      privkey = %PrivateKey{d: 123_414_253_234_542_345_423_623}
+      pubkey = PrivateKey.to_point(privkey)
+      {:ok, privkey: privkey, pubkey: pubkey}
+    end
+
+    test "verifies signatures produced by sign_message/2", %{privkey: privkey, pubkey: pubkey} do
+      for msg <- ["", "hello", String.duplicate("a", 300)] do
+        sig = Ecdsa.sign_message(privkey, msg)
+        assert Ecdsa.verify_message(pubkey, msg, sig)
+      end
+    end
+
+    test "verifies a Bitcoin Core signature against its pubkey" do
+      msg = "This is just a test message"
+
+      <<_header, r::binary-size(32), s::binary-size(32)>> =
+        Base.decode64!(
+          "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
+        )
+
+      sig = %Signature{r: :binary.decode_unsigned(r), s: :binary.decode_unsigned(s)}
+
+      {:ok, pubkey} =
+        Point.parse_public_key(
+          "03c150061989643d77162902b725409087959f15914649d4f06b6cc3f8c87bb238"
+        )
+
+      assert Ecdsa.verify_message(pubkey, msg, sig)
+    end
+
+    test "rejects wrong message, wrong key, and tampered signature", %{
+      privkey: privkey,
+      pubkey: pubkey
+    } do
+      msg = "hello"
+      sig = Ecdsa.sign_message(privkey, msg)
+
+      # wrong message
+      refute Ecdsa.verify_message(pubkey, "hello!", sig)
+
+      # wrong key
+      other_pubkey = PrivateKey.to_point(%PrivateKey{d: 999_999_999_999})
+      refute Ecdsa.verify_message(other_pubkey, msg, sig)
+
+      # tampered signature
+      tampered_sig = %Signature{r: sig.r, s: sig.s + 1}
+      refute Ecdsa.verify_message(pubkey, msg, tampered_sig)
+    end
+  end
 end

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -248,12 +248,9 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     end
   end
 
-  # digests independently derived from the standard preimage
-  # compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(byte_size(msg)) || msg
-  # and cross-checked with Python hashlib.
+  # derived from the standard preimage and cross-checked against Python hashlib
   @message_digest_test_cases [
     %{
-      # empty message: msg length compact_size is a single 0x00 byte
       msg: "",
       digest: "80e795d4a4caadd7047af389d9f7f220562feb6196032e2131e10563352c4bcc"
     },
@@ -262,7 +259,7 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       digest: "cf0447ec85f0ce7150a257db32ebfcb7523dae17c36dbd1be598779fec0484f4"
     },
     %{
-      # 300 bytes: msg length compact_size takes the 0xFD two-byte form (fd2c01)
+      # 300 bytes exercises the 0xFD two-byte compact_size form
       msg: String.duplicate("a", 300),
       digest: "3ec158a43b80359df647352dac1d37dbf26a94e5f06e5790760290c75cd11dc0"
     }
@@ -311,12 +308,8 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     end
 
     test "reproduces a Bitcoin Core signmessage signature byte for byte" do
-      # Vector from Bitcoin Core test/functional/rpc_signmessage.py:
-      #   priv_key = cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N (testnet WIF)
-      #   address  = mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB
-      #   message  = "This is just a test message"
-      #   expected_signature =
-      #     "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
+      # Bitcoin Core test/functional/rpc_signmessage.py, WIF
+      # cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N / mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB
       privkey = %PrivateKey{
         d: 0xD2B8A0116D641FE7D3036F8464628FB595B480414C13A301B3D4038C811C28B0
       }
@@ -328,7 +321,7 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
           "INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0="
         )
 
-      # header byte 0x20 = 27 + recovery_id 1 + 4 (compressed pubkey)
+      # header 0x20 = 27 + recovery_id 1 + 4 (compressed)
       <<0x20, r::binary-size(32), s::binary-size(32)>> = expected_sig
 
       sig = Ecdsa.sign_message(privkey, msg)
@@ -337,9 +330,6 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     end
 
     test "recovers Bitcoin Core's pubkey from its signature" do
-      # Same Bitcoin Core vector as above, verified via pubkey recovery: the
-      # WIF private key derives pubkey 03c150..., which hash160s to address
-      # mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB.
       msg = "This is just a test message"
 
       expected_sig =
@@ -348,7 +338,6 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
         )
 
       <<header, compact_sig::binary-size(64)>> = expected_sig
-      # recovery_id = header - 27 - 4 (compressed)
       recovery_id = header - 31
 
       assert {:ok, "03c150061989643d77162902b725409087959f15914649d4f06b6cc3f8c87bb238"} ==
@@ -395,16 +384,27 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       msg = "hello"
       sig = Ecdsa.sign_message(privkey, msg)
 
-      # wrong message
       refute Ecdsa.verify_message(pubkey, "hello!", sig)
 
-      # wrong key
       other_pubkey = PrivateKey.to_point(%PrivateKey{d: 999_999_999_999})
       refute Ecdsa.verify_message(other_pubkey, msg, sig)
 
-      # tampered signature
-      tampered_sig = %Signature{r: sig.r, s: sig.s + 1}
-      refute Ecdsa.verify_message(pubkey, msg, tampered_sig)
+      refute Ecdsa.verify_message(pubkey, msg, %Signature{r: sig.r, s: sig.s + 1})
+    end
+
+    test "verifies a signature whose r or s has a leading zero byte" do
+      # s here is 31 bytes when minimally encoded, so the compact signature
+      # handed to recovery must be zero-padded to 32 bytes per scalar
+      {:ok, privkey} =
+        PrivateKey.new(0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF)
+
+      pubkey = PrivateKey.to_point(privkey)
+      sig = Ecdsa.sign_message(privkey, "m32")
+
+      assert byte_size(:binary.encode_unsigned(sig.r)) < 32 or
+               byte_size(:binary.encode_unsigned(sig.s)) < 32
+
+      assert Ecdsa.verify_message(pubkey, "m32", sig)
     end
   end
 end


### PR DESCRIPTION
## Summary

`Ecdsa.sign_message/2` hashed `"Bitcoin Signed Message:\n" <> msg` directly, omitting both CompactSize length prefixes required by the standard Bitcoin signed-message scheme. The correct preimage is:

```
compact_size(24) || "Bitcoin Signed Message:\n" || compact_size(byte_size(msg)) || msg
```

(the magic string is 24 bytes, so its prefix is the single byte `0x18`), and the digest is the double-SHA256 of that. The message-length prefix is also what makes the construction unambiguous.

For `msg = "hello"`:

| | digest |
|---|---|
| old (bitcoinex) | `5f03c0aeae12de40ebd6d15ef9c900aaefee6939fa8d051f231fe4e68674a568` |
| new (standard) | `cf0447ec85f0ce7150a257db32ebfcb7523dae17c36dbd1be598779fec0484f4` |

The old output was verifiable by **no other wallet** — signatures produced here could not be checked by Bitcoin Core, Electrum, etc., and theirs could not be checked here — defeating the function's only purpose (proof of key ownership).

## Changes

- `Ecdsa.message_digest/1` (new): returns the 32-byte digest of the standard preimage. Uses `Transaction.Utils.serialize_compact_size_unsigned_int/1` for the varints (`Utils.encode_int/1` was avoided deliberately: its `when i > 0` guard raises on the empty message).
- `Ecdsa.sign_message/2`: now signs `message_digest(msg)`.
- `Ecdsa.verify_message/3` (new): verifies a `(pubkey, msg, signature)` triple via public key recovery (`ecdsa_recover_compact/3`). Its absence is why this bug went unnoticed — nothing in the library ever verified a signed message.

## Tests

- Digest known-answer tests for `""` (the `encode_int` edge case), `"hello"`, and a 300-byte message (message-length varint in the `0xFD` two-byte form). Values derived from the spec by hand and cross-checked with Python `hashlib`.
- Regression guard: asserts the digest is not the old unprefixed one.
- Sign → recover round-trip across several messages, including empty and long.
- **Interop vector from Bitcoin Core** (`test/functional/rpc_signmessage.py`): WIF `cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N` / address `mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB` / message `"This is just a test message"` / signature `INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0=`. The fixed `sign_message/2` reproduces Core's signature byte for byte (RFC6979 + low-s), and pubkey recovery over `message_digest/1` returns Core's pubkey. The vector was independently validated offline (WIF checksum, address derivation, EC verification) before pinning.
- `verify_message/3` positives plus negatives (wrong message, wrong key, tampered signature).

All new tests fail against the unfixed code.

## Breaking change

**This is a breaking change** for anyone relying on the old (non-interoperable) digest: signatures produced by the previous `sign_message/2` will not verify against the new digest. Noted in `CHANGELOG.md` under Unreleased.

## Note on concurrent work

Two concurrent PRs touch neighbouring functions in the same module (`verify_signature/3` in `ecdsa.ex`, and `parse_signature/1`/`serialize_signature/1` in `secp256k1.ex`). This diff deliberately avoids modifying any of those — it only adds `message_digest/1` and `verify_message/3` and rewrites the body of `sign_message/2` — so the branches should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
