### PR TITLE
Fix signature serialization, non-terminating parse, address length and pubkey validation

### DIFF
--- a/lib/address.ex
+++ b/lib/address.ex
@@ -19,19 +19,28 @@ defmodule Bitcoinex.Address do
 
   @doc """
   Accepts a public key hash, network, and address_type and returns its address.
+
+  The hash must be exactly 20 bytes (the output of hash160), otherwise the
+  resulting address would be unspendable and any funds sent to it burned.
   """
-  @spec encode(binary, Bitcoinex.Network.network_name(), address_type) :: String.t()
-  def encode(pubkey_hash, network_name, :p2pkh) do
+  @spec encode(binary, Bitcoinex.Network.network_name(), address_type) ::
+          String.t() | {:error, String.t()}
+  def encode(pubkey_hash, network_name, :p2pkh) when byte_size(pubkey_hash) == 20 do
     network = Network.get_network(network_name)
     decimal_prefix = network.p2pkh_version_decimal_prefix
 
     Base58.encode(<<decimal_prefix>> <> pubkey_hash)
   end
 
-  def encode(script_hash, network_name, :p2sh) do
+  def encode(script_hash, network_name, :p2sh) when byte_size(script_hash) == 20 do
     network = Network.get_network(network_name)
     decimal_prefix = network.p2sh_version_decimal_prefix
     Base58.encode(<<decimal_prefix>> <> script_hash)
+  end
+
+  def encode(hash, _network_name, address_type)
+      when is_binary(hash) and address_type in [:p2pkh, :p2sh] do
+    {:error, "hash must be exactly 20 bytes"}
   end
 
   @doc """
@@ -111,8 +120,9 @@ defmodule Bitcoinex.Address do
   end
 
   defp is_valid_base58_check_address?(address, valid_prefix) do
+    # a valid address decodes to exactly 21 bytes: 1 version byte + 20-byte hash160
     case Base58.decode(address) do
-      {:ok, <<^valid_prefix::8, _::binary>>} ->
+      {:ok, <<^valid_prefix::8, _hash::binary-size(20)>>} ->
         true
 
       _ ->

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -19,11 +19,10 @@ defmodule Bitcoinex.Address do
 
   @doc """
   Accepts a public key hash, network, and address_type and returns its address.
-  The hash must be exactly 20 bytes: a p2pkh/p2sh script built around any other
-  length is unspendable.
+  The hash must be exactly 20 bytes — a p2pkh/p2sh script built around any other
+  length is unspendable — otherwise `ArgumentError` is raised.
   """
-  @spec encode(binary, Bitcoinex.Network.network_name(), address_type) ::
-          String.t() | {:error, String.t()}
+  @spec encode(binary, Bitcoinex.Network.network_name(), address_type) :: String.t()
   def encode(pubkey_hash, network_name, :p2pkh) when byte_size(pubkey_hash) == 20 do
     network = Network.get_network(network_name)
     decimal_prefix = network.p2pkh_version_decimal_prefix
@@ -39,7 +38,8 @@ defmodule Bitcoinex.Address do
 
   def encode(hash, _network_name, address_type)
       when is_binary(hash) and address_type in [:p2pkh, :p2sh] do
-    {:error, "hash must be exactly 20 bytes"}
+    raise ArgumentError,
+          "#{address_type} hash must be exactly 20 bytes, got #{byte_size(hash)}"
   end
 
   @doc """

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -19,9 +19,8 @@ defmodule Bitcoinex.Address do
 
   @doc """
   Accepts a public key hash, network, and address_type and returns its address.
-
-  The hash must be exactly 20 bytes (the output of hash160), otherwise the
-  resulting address would be unspendable and any funds sent to it burned.
+  The hash must be exactly 20 bytes: a p2pkh/p2sh script built around any other
+  length is unspendable.
   """
   @spec encode(binary, Bitcoinex.Network.network_name(), address_type) ::
           String.t() | {:error, String.t()}
@@ -120,7 +119,6 @@ defmodule Bitcoinex.Address do
   end
 
   defp is_valid_base58_check_address?(address, valid_prefix) do
-    # a valid address decodes to exactly 21 bytes: 1 version byte + 20-byte hash160
     case Base58.decode(address) do
       {:ok, <<^valid_prefix::8, _hash::binary-size(20)>>} ->
         true

--- a/lib/extendedkey.ex
+++ b/lib/extendedkey.ex
@@ -303,10 +303,13 @@ defmodule Bitcoinex.ExtendedKey do
     end
   end
 
-  # verify if point is valid on secp256k1
+  # verify if point is valid on secp256k1. An unparseable key is simply not a
+  # valid point: this runs on caller-supplied xpub bytes, so it must never raise.
   defp check_point(key) do
-    {:ok, pubkey} = Point.parse_public_key(key)
-    Bitcoinex.Secp256k1.verify_point(pubkey)
+    case Point.parse_public_key(key) do
+      {:ok, pubkey} -> Bitcoinex.Secp256k1.verify_point(pubkey)
+      {:error, _msg} -> false
+    end
   end
 
   @doc """

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -109,10 +109,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     DateTime.from_unix!(invoice.timestamp + expiry)
   end
 
-  # The data part must be long enough to contain at least a timestamp and a
-  # signature. Without this check, a shorter data part yields an empty or
-  # truncated signature, which previously either raised or hung forever in
-  # signature parsing.
+  # a shorter data part would leave an empty or truncated signature
   defp validate_data_length(data)
        when length(data) >= @timestamp_base32_length + @signature_base32_length,
        do: :ok

--- a/lib/lightning_network/invoice.ex
+++ b/lib/lightning_network/invoice.ex
@@ -74,6 +74,7 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
   def decode(invoice) when is_binary(invoice) do
     with {:ok, {_encoding_type, hrp, data}} <- Bech32.decode(invoice, @max_invoice_length),
          {:ok, {network, amount_msat}} <- parse_hrp(hrp),
+         :ok <- validate_data_length(data),
          {invoice_data, signature_data} = split_at(data, -@signature_base32_length),
          {:ok, parsed_data} <-
            parse_invoice_data(invoice_data, network),
@@ -107,6 +108,16 @@ defmodule Bitcoinex.LightningNetwork.Invoice do
     expiry = invoice.expiry
     DateTime.from_unix!(invoice.timestamp + expiry)
   end
+
+  # The data part must be long enough to contain at least a timestamp and a
+  # signature. Without this check, a shorter data part yields an empty or
+  # truncated signature, which previously either raised or hung forever in
+  # signature parsing.
+  defp validate_data_length(data)
+       when length(data) >= @timestamp_base32_length + @signature_base32_length,
+       do: :ok
+
+  defp validate_data_length(_), do: {:error, :invoice_data_too_short}
 
   # checking some invariant for invoice
   # TODO Could we use ecto(without SQL) for this?

--- a/lib/psbt.ex
+++ b/lib/psbt.ex
@@ -1180,7 +1180,11 @@ defmodule Bitcoinex.PSBT.In do
           non_witness_utxo: Transaction.t() | nil,
           witness_utxo: Out.t() | nil,
           partial_sig:
-            list(%{public_key: Point.t(), signature: binary(), sighash_flag: non_neg_integer()})
+            list(%{
+              public_key: Point.t(),
+              signature: Signature.t(),
+              sighash_flag: non_neg_integer()
+            })
             | nil,
           sighash_type: non_neg_integer() | nil,
           redeem_script: Script.t() | nil,
@@ -1244,7 +1248,7 @@ defmodule Bitcoinex.PSBT.In do
 
     * `:non_witness_utxo` — a `Transaction.t()`
     * `:witness_utxo` — a `Transaction.Out.t()`
-    * `:partial_sig` — `%{public_key: Point.t(), signature: binary(), sighash_flag: flag}` (repeatable), where `signature` is the raw DER-encoded ECDSA signature (stored verbatim, so it round-trips byte-for-byte) and `flag` (like `:sighash_type`) must be one of the valid sighash flags `0x01`/`0x02`/`0x03` optionally `| 0x80`
+    * `:partial_sig` — `%{public_key: Point.t(), signature: Signature.t(), sighash_flag: flag}` (repeatable), where `signature` may also be given as raw DER bytes and is stored as the parsed `Signature.t()`, and `flag` (like `:sighash_type`) must be one of the valid sighash flags `0x01`/`0x02`/`0x03` optionally `| 0x80`
     * `:sighash_type` — one of the valid sighash flag integers
     * `:redeem_script` / `:witness_script` / `:final_scriptsig` — a `Script.t()` or its hex/binary
     * `:bip32_derivation` — `%{public_key: Point.t(), origin: KeyOrigin.t()}` (repeatable)
@@ -1285,11 +1289,12 @@ defmodule Bitcoinex.PSBT.In do
           sighash_flag: sighash_flag
         } = record
       )
-      when is_binary(signature) and sighash_flag in @valid_sighash_flags do
-    # Signatures are kept as their raw DER bytes so they round-trip verbatim, but
-    # still validate that those bytes are well-formed DER so a garbage partial_sig
-    # is rejected rather than stored.
-    with {:ok, _signature} <- Signature.der_parse_signature(signature),
+      when sighash_flag in @valid_sighash_flags do
+    # Signatures are stored parsed. Raw DER bytes are accepted for convenience
+    # and normalized; either way the scalars are validated, so a garbage
+    # partial_sig is rejected rather than stored.
+    with {:ok, signature} <- normalize_signature(signature),
+         record = %{record | signature: signature},
          {:ok, partial_sigs} <-
            PsbtUtils.append_unique(input.partial_sig, record, &Point.sec(&1.public_key)) do
       {:ok, %In{input | partial_sig: partial_sigs}}
@@ -1715,10 +1720,10 @@ defmodule Bitcoinex.PSBT.In do
     end)
   end
 
-  # partial_sig signatures are stored as their raw DER bytes; the finalized
-  # scriptSig/witness pushes those bytes followed by the 1-byte sighash flag.
+  # The finalized scriptSig/witness pushes the DER-encoded signature followed by
+  # the 1-byte sighash flag.
   defp signature_bytes(%{signature: signature, sighash_flag: sighash_flag}) do
-    signature <> <<sighash_flag>>
+    Signature.der_serialize_signature(signature) <> <<sighash_flag>>
   end
 
   # Builds a witness stack from raw byte items.
@@ -1767,6 +1772,15 @@ defmodule Bitcoinex.PSBT.In do
   end
 
   defp with_script(_script, _put_fun), do: {:error, :invalid_field}
+
+  # A partial_sig may be supplied as a Signature or as raw DER bytes. Both are
+  # revalidated: a hand-built struct can carry scalars outside [1, n-1], which
+  # der_serialize_signature/1 could not encode.
+  defp normalize_signature(%Signature{r: r, s: s}), do: Signature.new(r, s)
+
+  defp normalize_signature(der) when is_binary(der), do: Signature.der_parse_signature(der)
+
+  defp normalize_signature(_signature), do: {:error, :invalid_partial_sig}
 
   # Validates that a string is hex and normalizes it to lowercase, so the Updater
   # rejects values that would otherwise raise at encode time (the serializers use
@@ -2007,11 +2021,10 @@ defmodule Bitcoinex.PSBT.In do
   end
 
   # Splits a PSBT partial_sig value into its DER signature and trailing 1-byte
-  # sighash flag. The DER signature is stored as raw bytes rather than parsed into
-  # a Signature struct: re-serializing a parsed ECDSA signature yields canonical
-  # DER, which is not guaranteed to reproduce a non-canonically-encoded input, so
-  # storing the raw bytes is what makes partial_sig round-trip losslessly. The
-  # bytes are still validated as well-formed DER so a malformed value is rejected.
+  # sighash flag, and stores the signature parsed. der_parse_signature/1 accepts
+  # only canonical (BIP66) DER and der_serialize_signature/1 reproduces exactly
+  # that encoding, so the struct is a lossless representation of the input bytes
+  # and partial_sig still round-trips byte-for-byte.
   defp parse_partial_sig(public_key, value) do
     signature_length = byte_size(value) - 1
     <<der_signature::binary-size(signature_length), sighash_flag::8>> = value
@@ -2022,8 +2035,8 @@ defmodule Bitcoinex.PSBT.In do
 
       true ->
         case Signature.der_parse_signature(der_signature) do
-          {:ok, _signature} ->
-            {:ok, %{public_key: public_key, signature: der_signature, sighash_flag: sighash_flag}}
+          {:ok, signature} ->
+            {:ok, %{public_key: public_key, signature: signature, sighash_flag: sighash_flag}}
 
           {:error, reason} ->
             {:error, reason}
@@ -2134,7 +2147,7 @@ defmodule Bitcoinex.PSBT.In do
          sighash_flag: sighash_flag
        }) do
     key = <<@psbt_in_partial_sig::big-size(8)>> <> Point.sec(public_key)
-    value = signature <> <<sighash_flag>>
+    value = Signature.der_serialize_signature(signature) <> <<sighash_flag>>
     PsbtUtils.serialize_kv(key, value)
   end
 

--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -43,9 +43,7 @@ defmodule Bitcoinex.Secp256k1.Point do
     x = :binary.decode_unsigned(x_bytes)
     y = :binary.decode_unsigned(y_bytes)
 
-    # x and y must be valid field elements and the point must satisfy the
-    # curve equation, otherwise off-curve points would be accepted and flow
-    # into EC arithmetic (invalid-curve attacks) or produce unspendable keys.
+    # off-curve points must be rejected before they reach EC arithmetic
     if x < @p and y < @p and on_curve?(x, y) do
       {:ok, %__MODULE__{x: x, y: y}}
     else
@@ -57,9 +55,7 @@ defmodule Bitcoinex.Secp256k1.Point do
   def parse_public_key(<<prefix::binary-size(1), x_bytes::binary-size(32)>>) do
     x = :binary.decode_unsigned(x_bytes)
 
-    # x must be a valid field element; otherwise get_y would silently
-    # reduce it mod p and accept a different point (lift_x already rejects
-    # x >= p, so both entry points now agree).
+    # get_y would otherwise silently reduce x mod p and accept a different point
     if x >= @p do
       {:error, "invalid public key"}
     else
@@ -90,7 +86,6 @@ defmodule Bitcoinex.Secp256k1.Point do
     |> parse_public_key()
   end
 
-  # checks that the point satisfies the curve equation y^2 = x^3 + 7 (mod p)
   defp on_curve?(x, y) do
     rem(y * y, @p) == rem(x * x * x + 7, @p)
   end

--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -39,29 +39,46 @@ defmodule Bitcoinex.Secp256k1.Point do
   parse_public_key parses a public key
   """
   @spec parse_public_key(binary) :: {:ok, t()} | {:error, String.t()}
-  def parse_public_key(<<0x04, x::binary-size(32), y::binary-size(32)>>) do
-    {:ok, %__MODULE__{x: :binary.decode_unsigned(x), y: :binary.decode_unsigned(y)}}
+  def parse_public_key(<<0x04, x_bytes::binary-size(32), y_bytes::binary-size(32)>>) do
+    x = :binary.decode_unsigned(x_bytes)
+    y = :binary.decode_unsigned(y_bytes)
+
+    # x and y must be valid field elements and the point must satisfy the
+    # curve equation, otherwise off-curve points would be accepted and flow
+    # into EC arithmetic (invalid-curve attacks) or produce unspendable keys.
+    if x < @p and y < @p and on_curve?(x, y) do
+      {:ok, %__MODULE__{x: x, y: y}}
+    else
+      {:error, "invalid public key"}
+    end
   end
 
   # Above matches with uncompressed keys. Below matches with compressed keys
   def parse_public_key(<<prefix::binary-size(1), x_bytes::binary-size(32)>>) do
     x = :binary.decode_unsigned(x_bytes)
 
-    case :binary.decode_unsigned(prefix) do
-      2 ->
-        case Bitcoinex.Secp256k1.get_y(x, false) do
-          {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
-          _ -> {:error, "invalid public key"}
-        end
+    # x must be a valid field element; otherwise get_y would silently
+    # reduce it mod p and accept a different point (lift_x already rejects
+    # x >= p, so both entry points now agree).
+    if x >= @p do
+      {:error, "invalid public key"}
+    else
+      case :binary.decode_unsigned(prefix) do
+        2 ->
+          case Bitcoinex.Secp256k1.get_y(x, false) do
+            {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
+            _ -> {:error, "invalid public key"}
+          end
 
-      3 ->
-        case Bitcoinex.Secp256k1.get_y(x, true) do
-          {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
-          _ -> {:error, "invalid public key"}
-        end
+        3 ->
+          case Bitcoinex.Secp256k1.get_y(x, true) do
+            {:ok, y} -> {:ok, %__MODULE__{x: x, y: y}}
+            _ -> {:error, "invalid public key"}
+          end
 
-      _ ->
-        {:error, "invalid public key"}
+        _ ->
+          {:error, "invalid public key"}
+      end
     end
   end
 
@@ -71,6 +88,11 @@ defmodule Bitcoinex.Secp256k1.Point do
     |> String.downcase()
     |> Base.decode16!(case: :lower)
     |> parse_public_key()
+  end
+
+  # checks that the point satisfies the curve equation y^2 = x^3 + 7 (mod p)
+  defp on_curve?(x, y) do
+    rem(y * y, @p) == rem(x * x * x + 7, @p)
   end
 
   @doc """

--- a/lib/secp256k1/point.ex
+++ b/lib/secp256k1/point.ex
@@ -78,13 +78,17 @@ defmodule Bitcoinex.Secp256k1.Point do
     end
   end
 
-  # Allow parse_public_key to parse SEC strings
-  def parse_public_key(key) do
-    key
-    |> String.downcase()
-    |> Base.decode16!(case: :lower)
-    |> parse_public_key()
+  # Allow parse_public_key to parse SEC strings. Only the two lengths that can
+  # hex-decode to a SEC key are accepted: an unguarded clause would raise on any
+  # non-hex binary, and this is reached with caller-supplied script bytes.
+  def parse_public_key(key) when is_binary(key) and byte_size(key) in [66, 130] do
+    case Utils.hex_to_bin(key) do
+      {:error, msg} -> {:error, msg}
+      key_bytes -> parse_public_key(key_bytes)
+    end
   end
+
+  def parse_public_key(_key), do: {:error, "invalid public key"}
 
   defp on_curve?(x, y) do
     rem(y * y, @p) == rem(x * x * x + 7, @p)

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -16,6 +16,8 @@ defmodule Bitcoinex.Secp256k1 do
     """
     alias Bitcoinex.Utils
 
+    @compact_signature_scalar_limit :erlang.bsl(1, 256)
+
     @type t :: %__MODULE__{
             r: pos_integer(),
             s: pos_integer()
@@ -105,11 +107,16 @@ defmodule Bitcoinex.Secp256k1 do
 
     defp parse_sig_key(_data), do: {:error, "invalid signature key marker"}
 
-    @spec serialize_signature(t()) :: binary
-    def serialize_signature(%__MODULE__{r: r, s: s}) do
+    @spec serialize_signature(t()) :: binary | {:error, String.t()}
+    def serialize_signature(%__MODULE__{r: r, s: s})
+        when is_integer(r) and is_integer(s) and r >= 0 and s >= 0 and
+               r < @compact_signature_scalar_limit and s < @compact_signature_scalar_limit do
       # each scalar must occupy exactly 32 bytes
       Utils.int_to_big(r, 32) <> Utils.int_to_big(s, 32)
     end
+
+    def serialize_signature(%__MODULE__{}),
+      do: {:error, "signature scalars must be non-negative 32-byte integers"}
 
     @doc """
     der_serialize_signature returns the DER serialization of an ecdsa signature

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -56,8 +56,12 @@ defmodule Bitcoinex.Secp256k1 do
       end
     end
 
-    # attempt to parse 64-byte string
-    def parse_signature(compact_sig) when is_binary(compact_sig) do
+    # attempt to parse a hex-encoded compact signature. A 64-byte compact
+    # signature is 128 hex characters; anything else (including "", which
+    # hex-decodes to itself and previously recursed forever) falls through
+    # to the invalid-size clause below.
+    def parse_signature(compact_sig)
+        when is_binary(compact_sig) and byte_size(compact_sig) == 128 do
       case Utils.hex_to_bin(compact_sig) do
         {:error, msg} ->
           {:error, msg}
@@ -105,7 +109,9 @@ defmodule Bitcoinex.Secp256k1 do
 
     @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s}) do
-      :binary.encode_unsigned(r) <> :binary.encode_unsigned(s)
+      # r and s must each be exactly 32 bytes; minimal encodings would
+      # produce short, invalid signatures whenever r or s has leading zeros.
+      Utils.int_to_big(r, 32) <> Utils.int_to_big(s, 32)
     end
 
     @doc """

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -56,10 +56,8 @@ defmodule Bitcoinex.Secp256k1 do
       end
     end
 
-    # attempt to parse a hex-encoded compact signature. A 64-byte compact
-    # signature is 128 hex characters; anything else (including "", which
-    # hex-decodes to itself and previously recursed forever) falls through
-    # to the invalid-size clause below.
+    # a 64-byte compact signature is 128 hex characters. The length guard matters:
+    # "" hex-decodes to itself, so an unguarded clause recurses forever.
     def parse_signature(compact_sig)
         when is_binary(compact_sig) and byte_size(compact_sig) == 128 do
       case Utils.hex_to_bin(compact_sig) do
@@ -109,8 +107,7 @@ defmodule Bitcoinex.Secp256k1 do
 
     @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s}) do
-      # r and s must each be exactly 32 bytes; minimal encodings would
-      # produce short, invalid signatures whenever r or s has leading zeros.
+      # each scalar must occupy exactly 32 bytes
       Utils.int_to_big(r, 32) <> Utils.int_to_big(s, 32)
     end
 

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -39,23 +39,7 @@ defmodule Bitcoinex.Secp256k1 do
       r = :binary.decode_unsigned(r)
       s = :binary.decode_unsigned(s)
 
-      # Verify that r,s are integers in [1, n-1] where n is the integer order of G.
-      cond do
-        r < 1 ->
-          {:error, "invalid signature"}
-
-        r > Params.curve().n - 1 ->
-          {:error, "invalid signature"}
-
-        s < 1 ->
-          {:error, "invalid signature"}
-
-        s > Params.curve().n - 1 ->
-          {:error, "invalid signature"}
-
-        true ->
-          {:ok, %Signature{r: r, s: s}}
-      end
+      new_signature(r, s)
     end
 
     # a 64-byte compact signature is 128 hex characters. The length guard matters:
@@ -84,7 +68,7 @@ defmodule Bitcoinex.Secp256k1 do
         with {:ok, r, rest} <- parse_sig_key(body),
              {:ok, s, rest} <- parse_sig_key(rest) do
           if rest == <<>> do
-            {:ok, %Signature{r: r, s: s}}
+            new_signature(r, s)
           else
             {:error, "invalid signature: signature is too long"}
           end
@@ -98,7 +82,9 @@ defmodule Bitcoinex.Secp256k1 do
     # past the end of the signature) is a clean error, never a raise: this is
     # reached from PSBT partial_sig validation with caller-supplied bytes.
     defp parse_sig_key(<<0x02, k_len, k::binary-size(k_len), rest::binary>>) do
-      {:ok, :binary.decode_unsigned(k), rest}
+      with :ok <- validate_der_integer(k) do
+        {:ok, :binary.decode_unsigned(k), rest}
+      end
     end
 
     defp parse_sig_key(<<0x02, _rest::binary>>) do
@@ -106,6 +92,33 @@ defmodule Bitcoinex.Secp256k1 do
     end
 
     defp parse_sig_key(_data), do: {:error, "invalid signature key marker"}
+
+    # DER INTEGERs are big-endian two's complement and must use the shortest
+    # possible encoding. Without these checks a single (r,s) has many valid
+    # byte encodings, and `<<0x02, 0x00>>` decodes to the forbidden scalar 0.
+    defp validate_der_integer(<<>>), do: {:error, "invalid signature: empty integer"}
+
+    defp validate_der_integer(<<first, _::binary>>) when (first &&& 0x80) != 0,
+      do: {:error, "invalid signature: negative integer"}
+
+    defp validate_der_integer(<<0x00, second, _::binary>>) when (second &&& 0x80) == 0,
+      do: {:error, "invalid signature: non-minimally encoded integer"}
+
+    defp validate_der_integer(k) when byte_size(k) > 33,
+      do: {:error, "invalid signature: integer too large"}
+
+    defp validate_der_integer(_k), do: :ok
+
+    # r and s must both be scalars in [1, n-1], where n is the order of G.
+    defp new_signature(r, s) do
+      n = Params.curve().n
+
+      if r >= 1 and r <= n - 1 and s >= 1 and s <= n - 1 do
+        {:ok, %Signature{r: r, s: s}}
+      else
+        {:error, "invalid signature"}
+      end
+    end
 
     @spec serialize_signature(t()) :: binary | {:error, String.t()}
     def serialize_signature(%__MODULE__{r: r, s: s})

--- a/lib/secp256k1/secp256k1.ex
+++ b/lib/secp256k1/secp256k1.ex
@@ -16,7 +16,9 @@ defmodule Bitcoinex.Secp256k1 do
     """
     alias Bitcoinex.Utils
 
-    @compact_signature_scalar_limit :erlang.bsl(1, 256)
+    # A signature scalar is serialized as at most 32 bytes (compact) or a 33-byte
+    # DER INTEGER, so both serializers are bounded by 2^256.
+    @scalar_encoding_limit :erlang.bsl(1, 256)
 
     @type t :: %__MODULE__{
             r: pos_integer(),
@@ -39,7 +41,7 @@ defmodule Bitcoinex.Secp256k1 do
       r = :binary.decode_unsigned(r)
       s = :binary.decode_unsigned(s)
 
-      new_signature(r, s)
+      new(r, s)
     end
 
     # a 64-byte compact signature is 128 hex characters. The length guard matters:
@@ -68,7 +70,7 @@ defmodule Bitcoinex.Secp256k1 do
         with {:ok, r, rest} <- parse_sig_key(body),
              {:ok, s, rest} <- parse_sig_key(rest) do
           if rest == <<>> do
-            new_signature(r, s)
+            new(r, s)
           else
             {:error, "invalid signature: signature is too long"}
           end
@@ -109,8 +111,12 @@ defmodule Bitcoinex.Secp256k1 do
 
     defp validate_der_integer(_k), do: :ok
 
-    # r and s must both be scalars in [1, n-1], where n is the order of G.
-    defp new_signature(r, s) do
+    @doc """
+    new builds a Signature from r and s, which must both be scalars in
+    [1, n-1], where n is the integer order of G.
+    """
+    @spec new(integer, integer) :: {:ok, t()} | {:error, String.t()}
+    def new(r, s) when is_integer(r) and is_integer(s) do
       n = Params.curve().n
 
       if r >= 1 and r <= n - 1 and s >= 1 and s <= n - 1 do
@@ -120,28 +126,37 @@ defmodule Bitcoinex.Secp256k1 do
       end
     end
 
-    @spec serialize_signature(t()) :: binary | {:error, String.t()}
+    def new(_r, _s), do: {:error, "invalid signature"}
+
+    @spec serialize_signature(t()) :: binary
     def serialize_signature(%__MODULE__{r: r, s: s})
-        when is_integer(r) and is_integer(s) and r >= 0 and s >= 0 and
-               r < @compact_signature_scalar_limit and s < @compact_signature_scalar_limit do
+        when is_integer(r) and is_integer(s) and r >= 1 and s >= 1 and
+               r < @scalar_encoding_limit and s < @scalar_encoding_limit do
       # each scalar must occupy exactly 32 bytes
       Utils.int_to_big(r, 32) <> Utils.int_to_big(s, 32)
     end
 
-    def serialize_signature(%__MODULE__{}),
-      do: {:error, "signature scalars must be non-negative 32-byte integers"}
+    def serialize_signature(%__MODULE__{r: r, s: s}) do
+      raise ArgumentError,
+            "signature scalars must be integers in [1, 2^256): got r=#{inspect(r)}, s=#{inspect(s)}"
+    end
 
     @doc """
     der_serialize_signature returns the DER serialization of an ecdsa signature
     """
-    @spec der_serialize_signature(Signature.t()) :: binary
-    def der_serialize_signature(%Signature{r: r, s: s}) do
+    @spec der_serialize_signature(t()) :: binary
+    def der_serialize_signature(%Signature{r: r, s: s})
+        when is_integer(r) and is_integer(s) and r >= 1 and s >= 1 and
+               r < @scalar_encoding_limit and s < @scalar_encoding_limit do
       r_bytes = serialize_sig_key(r)
       s_bytes = serialize_sig_key(s)
       <<0x30>> <> len_as_bytes(r_bytes <> s_bytes) <> r_bytes <> s_bytes
     end
 
-    def der_serialize_signature(_), do: {:error, "Signature object required"}
+    def der_serialize_signature(signature) do
+      raise ArgumentError,
+            "Signature with scalars in [1, 2^256) required, got #{inspect(signature)}"
+    end
 
     defp serialize_sig_key(k) do
       k

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -251,8 +251,6 @@ defmodule Bitcoinex.AddressTest do
     end
 
     test "return error when encoding a hash that is not 20 bytes" do
-      # a 32-byte SHA-256 or a 33-byte pubkey in place of a hash160 would
-      # otherwise mint a valid-looking address that burns any funds sent to it
       sha256 = :crypto.hash(:sha256, "x")
 
       pubkey =
@@ -281,7 +279,7 @@ defmodule Bitcoinex.AddressTest do
 
   describe "is_valid?/2 payload length" do
     test "return false for a base58check address whose payload is not 20 bytes" do
-      # valid checksum and version byte, but only 3 payload bytes
+      # valid checksum and version byte, 3 payload bytes
       short_address = Bitcoinex.Base58.encode(<<0, 1, 2, 3>>)
 
       refute Address.is_valid?(short_address, :mainnet)

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -250,7 +250,7 @@ defmodule Bitcoinex.AddressTest do
       assert "3BfqJjn7H2jsbKd2NVHGP4sQWQ2bQWBRLv" == Address.encode(script_hash, :mainnet, :p2sh)
     end
 
-    test "return error when encoding a hash that is not 20 bytes" do
+    test "raise when encoding a hash that is not 20 bytes" do
       sha256 = :crypto.hash(:sha256, "x")
 
       pubkey =
@@ -258,10 +258,10 @@ defmodule Bitcoinex.AddressTest do
           case: :lower
         )
 
-      for hash <- [sha256, pubkey, <<>>, <<0, 1, 2, 3>>],
+      for hash <- [sha256, pubkey, <<>>, <<0, 1, 2, 3>>, :binary.copy(<<0>>, 21)],
           network <- [:mainnet, :testnet],
           address_type <- [:p2pkh, :p2sh] do
-        assert {:error, _} = Address.encode(hash, network, address_type)
+        assert_raise ArgumentError, fn -> Address.encode(hash, network, address_type) end
       end
     end
 
@@ -279,11 +279,13 @@ defmodule Bitcoinex.AddressTest do
 
   describe "is_valid?/2 payload length" do
     test "return false for a base58check address whose payload is not 20 bytes" do
-      # valid checksum and version byte, 3 payload bytes
-      short_address = Bitcoinex.Base58.encode(<<0, 1, 2, 3>>)
+      # valid checksum and version byte, 3 and 21 payload bytes
+      for payload <- [<<0, 1, 2, 3>>, <<0>> <> :binary.copy(<<1>>, 21)] do
+        address = Bitcoinex.Base58.encode(payload)
 
-      refute Address.is_valid?(short_address, :mainnet)
-      refute Address.is_valid?(short_address, :mainnet, :p2pkh)
+        refute Address.is_valid?(address, :mainnet)
+        refute Address.is_valid?(address, :mainnet, :p2pkh)
+      end
     end
   end
 end

--- a/test/address_test.exs
+++ b/test/address_test.exs
@@ -249,5 +249,43 @@ defmodule Bitcoinex.AddressTest do
       script_hash = Base.decode16!("6d77fa9de297e9c536c6b23cfda1a8450bb5f765", case: :lower)
       assert "3BfqJjn7H2jsbKd2NVHGP4sQWQ2bQWBRLv" == Address.encode(script_hash, :mainnet, :p2sh)
     end
+
+    test "return error when encoding a hash that is not 20 bytes" do
+      # a 32-byte SHA-256 or a 33-byte pubkey in place of a hash160 would
+      # otherwise mint a valid-looking address that burns any funds sent to it
+      sha256 = :crypto.hash(:sha256, "x")
+
+      pubkey =
+        Base.decode16!("033b15e1b8c51bb947a134d17addc3eb6abbda551ad02137699636f907ad7e0f1a",
+          case: :lower
+        )
+
+      for hash <- [sha256, pubkey, <<>>, <<0, 1, 2, 3>>],
+          network <- [:mainnet, :testnet],
+          address_type <- [:p2pkh, :p2sh] do
+        assert {:error, _} = Address.encode(hash, network, address_type)
+      end
+    end
+
+    test "still encode and validate genuine 20-byte hashes across networks and types" do
+      hash = Base.decode16!("6dcd022b3c5e6439238eb333ec1d6ddd1973b5ba", case: :lower)
+
+      for network <- [:mainnet, :testnet],
+          address_type <- [:p2pkh, :p2sh] do
+        address = Address.encode(hash, network, address_type)
+        assert is_binary(address)
+        assert Address.is_valid?(address, network, address_type)
+      end
+    end
+  end
+
+  describe "is_valid?/2 payload length" do
+    test "return false for a base58check address whose payload is not 20 bytes" do
+      # valid checksum and version byte, but only 3 payload bytes
+      short_address = Bitcoinex.Base58.encode(<<0, 1, 2, 3>>)
+
+      refute Address.is_valid?(short_address, :mainnet)
+      refute Address.is_valid?(short_address, :mainnet, :p2pkh)
+    end
   end
 end

--- a/test/extendedkey_test.exs
+++ b/test/extendedkey_test.exs
@@ -262,6 +262,28 @@ defmodule Bitcoinex.Secp256k1.ExtendedKeyTest do
       assert ExtendedKey.parse_extended_key(t.xpub_m) == {:ok, t.xpub_m_obj}
       assert ExtendedKey.display_extended_key(t.xpub_m_obj) == t.xpub_m
     end
+
+    test "return an error, rather than raising, for an xpub whose key is unparseable" do
+      p = Bitcoinex.Secp256k1.Params.curve().p
+      xpub_prefix = <<0x04, 0x88, 0xB2, 0x1E>>
+
+      # BIP32 says to validate the public key on import, so each of these must
+      # be a clean error: x >= p, an invalid SEC prefix, and the identity point.
+      keys = [
+        <<0x02>> <> Bitcoinex.Utils.int_to_big(p + 1, 32),
+        <<0x05>> <> :binary.copy(<<0x01>>, 32),
+        <<0x02>> <> :binary.copy(<<0x00>>, 32)
+      ]
+
+      for key <- keys do
+        xkey =
+          xpub_prefix <>
+            <<0>> <> <<0, 0, 0, 0>> <> <<0, 0, 0, 0>> <> :binary.copy(<<0>>, 32) <> key
+
+        assert {:error, _} =
+                 ExtendedKey.parse_extended_key(Bitcoinex.Base58.append_checksum(xkey))
+      end
+    end
   end
 
   describe "to_extended_public_key/1" do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -721,6 +721,24 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
                Invoice.decode("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
     end
 
+    test "fail to decode an invoice whose data part is too short to hold a signature" do
+      # These used to hang forever (empty signature looping in
+      # parse_signature) or raise a MatchError, so run each decode in a
+      # task with a timeout to keep a regression from hanging the suite.
+      for invoice <- ["lnbc1qh65qct", "lnbc1w4pnfm"] do
+        task = Task.async(fn -> Invoice.decode(invoice) end)
+
+        case Task.yield(task, 5_000) do
+          {:ok, result} ->
+            assert {:error, _} = result
+
+          nil ->
+            Task.shutdown(task, :brutal_kill)
+            flunk("Invoice.decode(#{inspect(invoice)}) did not terminate within 5 seconds")
+        end
+      end
+    end
+
     test "fail to decode with invalid segwit addresses in mainnet", %{
       invalid_encoded_invoices: invalid_encoded_invoices
     } do

--- a/test/lightning_network/invoice_test.exs
+++ b/test/lightning_network/invoice_test.exs
@@ -722,9 +722,7 @@ defmodule Bitcoinex.LightningNetwork.InvoiceTest do
     end
 
     test "fail to decode an invoice whose data part is too short to hold a signature" do
-      # These used to hang forever (empty signature looping in
-      # parse_signature) or raise a MatchError, so run each decode in a
-      # task with a timeout to keep a regression from hanging the suite.
+      # timeout guarded: a regression here hangs forever rather than failing
       for invoice <- ["lnbc1qh65qct", "lnbc1w4pnfm"] do
         task = Task.async(fn -> Invoice.decode(invoice) end)
 

--- a/test/psbt_test.exs
+++ b/test/psbt_test.exs
@@ -336,16 +336,13 @@ defmodule Bitcoinex.PSBTTest do
       assert {:error, :non_witness_utxo_mismatch} = PSBT.decode(bad_vout)
     end
 
-    test "partial_sig stores the public key as a Point and the signature as raw DER bytes" do
+    test "partial_sig stores the public key as a Point and the signature as a Signature" do
       {:ok, psbt} = PSBT.decode(valid_vector(@p2sh_p2wsh_vector_index))
 
       assert [%{public_key: %Point{} = public_key, signature: signature, sighash_flag: 1}] =
                hd(psbt.inputs).partial_sig
 
-      # The signature is kept as raw bytes (not a parsed Signature struct) so it
-      # round-trips verbatim; it is still well-formed DER.
-      assert is_binary(signature)
-      assert {:ok, %Signature{}} = Signature.der_parse_signature(signature)
+      assert %Signature{} = signature
 
       assert Point.sec(public_key) ==
                Base.decode16!(
@@ -359,23 +356,27 @@ defmodule Bitcoinex.PSBTTest do
       [%{public_key: public_key, sighash_flag: sighash_flag} | _] = hd(psbt.inputs).partial_sig
 
       # Canonical DER whose r needs a leading 0x00 (high bit set) and whose s is
-      # only 31 bytes. Signatures are stored as raw bytes rather than a parsed
-      # Signature struct, so these lengths survive decode |> encode_b64 exactly.
+      # only 31 bytes. der_parse_signature/1 accepts only canonical DER and
+      # der_serialize_signature/1 reproduces it exactly, so storing the parsed
+      # Signature still reproduces these lengths across decode |> encode_b64.
       der =
         Base.decode16!(
           "3044022100" <> String.duplicate("dd", 32) <> "021f" <> String.duplicate("22", 31),
           case: :lower
         )
 
-      record = %{public_key: public_key, signature: der, sighash_flag: sighash_flag}
+      {:ok, input} =
+        PSBT.In.add_field(%In{hd(psbt.inputs) | partial_sig: nil}, :partial_sig, %{
+          public_key: public_key,
+          signature: der,
+          sighash_flag: sighash_flag
+        })
 
-      psbt = %PSBT{
-        psbt
-        | inputs: [%{hd(psbt.inputs) | partial_sig: [record]} | tl(psbt.inputs)]
-      }
+      psbt = %PSBT{psbt | inputs: [input | tl(psbt.inputs)]}
 
       assert {:ok, decoded} = PSBT.decode(encoded!(psbt))
-      assert [%{signature: ^der}] = hd(decoded.inputs).partial_sig
+      assert [%{signature: signature}] = hd(decoded.inputs).partial_sig
+      assert Signature.der_serialize_signature(signature) == der
     end
 
     test "rejects a partial_sig whose DER is well-formed but non-canonical" do
@@ -399,6 +400,41 @@ defmodule Bitcoinex.PSBTTest do
 
       assert {:error, :invalid_partial_sig} =
                PSBT.In.add_field(hd(psbt.inputs), :partial_sig, record)
+    end
+
+    test "add_field accepts a partial_sig as a Signature or as raw DER, storing a Signature" do
+      {:ok, psbt} = PSBT.decode(valid_vector(@p2sh_p2wsh_vector_index))
+      [%{public_key: public_key, sighash_flag: sighash_flag} | _] = hd(psbt.inputs).partial_sig
+      empty = %In{hd(psbt.inputs) | partial_sig: nil}
+
+      der =
+        Base.decode16!(
+          "3044022100" <> String.duplicate("dd", 32) <> "021f" <> String.duplicate("22", 31),
+          case: :lower
+        )
+
+      {:ok, signature} = Signature.der_parse_signature(der)
+
+      for supplied <- [der, signature] do
+        record = %{public_key: public_key, signature: supplied, sighash_flag: sighash_flag}
+        assert {:ok, input} = PSBT.In.add_field(empty, :partial_sig, record)
+        assert [%{signature: ^signature}] = input.partial_sig
+      end
+    end
+
+    test "rejects a partial_sig Signature whose scalars are out of range" do
+      {:ok, psbt} = PSBT.decode(valid_vector(@p2sh_p2wsh_vector_index))
+      [%{public_key: public_key, sighash_flag: sighash_flag} | _] = hd(psbt.inputs).partial_sig
+      n = Bitcoinex.Secp256k1.Params.curve().n
+
+      # A hand-built struct bypasses the parsers; der_serialize_signature/1
+      # could not encode these, so add_field must reject them up front.
+      for scalars <- [%Signature{r: 0, s: 1}, %Signature{r: 1, s: n}] do
+        record = %{public_key: public_key, signature: scalars, sighash_flag: sighash_flag}
+
+        assert {:error, :invalid_partial_sig} =
+                 PSBT.In.add_field(psbt.inputs |> hd(), :partial_sig, record)
+      end
     end
 
     test "round-trips a redeem_script that is not a finalizer-recognized template" do
@@ -885,7 +921,7 @@ defmodule Bitcoinex.PSBTTest do
 
       [input | rest] = a.inputs
       [sig | more_sigs] = input.partial_sig
-      tampered = %{sig | signature: sig.signature <> <<0>>}
+      tampered = %{sig | signature: %Signature{sig.signature | s: sig.signature.s - 1}}
       b = %PSBT{a | inputs: [%In{input | partial_sig: [tampered | more_sigs]} | rest]}
 
       assert {:error, :conflicting_field} = PSBT.combine(a, b)

--- a/test/psbt_test.exs
+++ b/test/psbt_test.exs
@@ -354,21 +354,20 @@ defmodule Bitcoinex.PSBTTest do
                )
     end
 
-    test "preserves the exact partial_sig bytes on round-trip, including non-canonical DER" do
+    test "preserves the exact partial_sig bytes on round-trip, including variable-length r,s" do
       {:ok, psbt} = PSBT.decode(valid_vector(@p2sh_p2wsh_vector_index))
       [%{public_key: public_key, sighash_flag: sighash_flag} | _] = hd(psbt.inputs).partial_sig
 
-      # A DER signature carrying an unnecessary leading 0x00 on r: parseable, but
-      # non-canonical. Parsing it into (r, s) and re-serializing would silently
-      # rewrite it to canonical DER; storing the raw bytes preserves it exactly
-      # across decode |> encode_b64.
-      noncanonical_der =
+      # Canonical DER whose r needs a leading 0x00 (high bit set) and whose s is
+      # only 31 bytes. Signatures are stored as raw bytes rather than a parsed
+      # Signature struct, so these lengths survive decode |> encode_b64 exactly.
+      der =
         Base.decode16!(
-          "3045022100" <> String.duplicate("11", 32) <> "0220" <> String.duplicate("22", 32),
+          "3044022100" <> String.duplicate("dd", 32) <> "021f" <> String.duplicate("22", 31),
           case: :lower
         )
 
-      record = %{public_key: public_key, signature: noncanonical_der, sighash_flag: sighash_flag}
+      record = %{public_key: public_key, signature: der, sighash_flag: sighash_flag}
 
       psbt = %PSBT{
         psbt
@@ -376,7 +375,30 @@ defmodule Bitcoinex.PSBTTest do
       }
 
       assert {:ok, decoded} = PSBT.decode(encoded!(psbt))
-      assert [%{signature: ^noncanonical_der}] = hd(decoded.inputs).partial_sig
+      assert [%{signature: ^der}] = hd(decoded.inputs).partial_sig
+    end
+
+    test "rejects a partial_sig whose DER is well-formed but non-canonical" do
+      {:ok, psbt} = PSBT.decode(valid_vector(@p2sh_p2wsh_vector_index))
+      [%{public_key: public_key, sighash_flag: sighash_flag} | _] = hd(psbt.inputs).partial_sig
+
+      # BIP66 requires minimally-encoded DER INTEGERs: an unnecessary leading
+      # 0x00 on r yields a second byte encoding of the same (r, s), which is
+      # signature malleability at the encoding layer.
+      noncanonical_der =
+        Base.decode16!(
+          "3045022100" <> String.duplicate("11", 32) <> "0220" <> String.duplicate("22", 32),
+          case: :lower
+        )
+
+      record = %{
+        public_key: public_key,
+        signature: noncanonical_der,
+        sighash_flag: sighash_flag
+      }
+
+      assert {:error, :invalid_partial_sig} =
+               PSBT.In.add_field(hd(psbt.inputs), :partial_sig, record)
     end
 
     test "round-trips a redeem_script that is not a finalizer-recognized template" do

--- a/test/secp256k1/point_test.exs
+++ b/test/secp256k1/point_test.exs
@@ -123,6 +123,32 @@ defmodule Bitcoinex.Secp256k1.PointTest do
 
       assert pk |> Point.sec() |> Point.parse_public_key() == {:ok, pk}
     end
+
+    test "return an error, rather than raising, for binaries that are not SEC keys" do
+      # Reached with caller-supplied script bytes (Script.is_multi?/1 pushes
+      # 33- and 65-byte items straight into parse_public_key/1), so a non-hex
+      # or wrong-length binary must never raise.
+      inputs = [
+        <<>>,
+        "not hex",
+        <<0x05>> <> :binary.copy(<<0xFF>>, 64),
+        :binary.copy(<<0xFF>>, 64),
+        String.duplicate("zz", 33)
+      ]
+
+      for input <- inputs do
+        assert {:error, _} = Point.parse_public_key(input)
+      end
+    end
+
+    test "still parse compressed and uncompressed keys given as hex" do
+      uncompressed_hex =
+        "048fdc3d8944cc8d8fe6c666c41a8ed42e60aa399861a756707e127a80b383d178edfbf94dda0487f7910d130f2a37a0647be9335eab5b8d3aa5242445e1604024"
+
+      assert {:ok, pk} = Point.parse_public_key(uncompressed_hex)
+      assert {:ok, ^pk} = Point.parse_public_key(String.upcase(uncompressed_hex))
+      assert {:ok, ^pk} = Point.parse_public_key(Base.encode16(Point.sec(pk), case: :lower))
+    end
   end
 
   describe "sec/1" do

--- a/test/secp256k1/point_test.exs
+++ b/test/secp256k1/point_test.exs
@@ -73,15 +73,13 @@ defmodule Bitcoinex.Secp256k1.PointTest do
     end
 
     test "return error for an uncompressed key that is not on the curve" do
-      # (1, 1) does not satisfy y^2 = x^3 + 7, so accepting it would expose
-      # EC arithmetic to invalid-curve attacks
+      # (1, 1) does not satisfy y^2 = x^3 + 7
       off_curve = <<0x04>> <> <<1::256>> <> <<1::256>>
       assert {:error, _} = Point.parse_public_key(off_curve)
     end
 
     test "return error for an uncompressed key with out-of-range coordinates" do
       p = Bitcoinex.Secp256k1.Params.curve().p
-      # coordinates must be valid field elements, i.e. < p
       x_ge_p = <<0x04>> <> Bitcoinex.Utils.int_to_big(p + 1, 32) <> <<1::256>>
       assert {:error, _} = Point.parse_public_key(x_ge_p)
 
@@ -101,8 +99,7 @@ defmodule Bitcoinex.Secp256k1.PointTest do
 
     test "return error for a compressed key with x >= p" do
       p = Bitcoinex.Secp256k1.Params.curve().p
-      # get_y used to silently reduce x mod p, so 02||(p+1) was accepted as
-      # if it were x = 1; lift_x already rejects x >= p
+
       for prefix <- [<<0x02>>, <<0x03>>] do
         assert {:error, _} =
                  Point.parse_public_key(prefix <> Bitcoinex.Utils.int_to_big(p + 1, 32))
@@ -118,14 +115,12 @@ defmodule Bitcoinex.Secp256k1.PointTest do
 
       {:ok, pk} = Point.parse_public_key(uncompressed)
 
-      # uncompressed serialization round-trips
       rebuilt =
         <<0x04>> <> Bitcoinex.Utils.int_to_big(pk.x, 32) <> Bitcoinex.Utils.int_to_big(pk.y, 32)
 
       assert rebuilt == uncompressed
       assert Point.parse_public_key(rebuilt) == {:ok, pk}
 
-      # compressed serialization round-trips
       assert pk |> Point.sec() |> Point.parse_public_key() == {:ok, pk}
     end
   end

--- a/test/secp256k1/point_test.exs
+++ b/test/secp256k1/point_test.exs
@@ -71,6 +71,63 @@ defmodule Bitcoinex.Secp256k1.PointTest do
       assert Point.parse_public_key(sec) == {:ok, pk}
       assert Point.serialize_public_key(pk) == sec
     end
+
+    test "return error for an uncompressed key that is not on the curve" do
+      # (1, 1) does not satisfy y^2 = x^3 + 7, so accepting it would expose
+      # EC arithmetic to invalid-curve attacks
+      off_curve = <<0x04>> <> <<1::256>> <> <<1::256>>
+      assert {:error, _} = Point.parse_public_key(off_curve)
+    end
+
+    test "return error for an uncompressed key with out-of-range coordinates" do
+      p = Bitcoinex.Secp256k1.Params.curve().p
+      # coordinates must be valid field elements, i.e. < p
+      x_ge_p = <<0x04>> <> Bitcoinex.Utils.int_to_big(p + 1, 32) <> <<1::256>>
+      assert {:error, _} = Point.parse_public_key(x_ge_p)
+
+      {:ok, pk} =
+        Point.parse_public_key(
+          Base.decode16!(
+            "048fdc3d8944cc8d8fe6c666c41a8ed42e60aa399861a756707e127a80b383d178edfbf94dda0487f7910d130f2a37a0647be9335eab5b8d3aa5242445e1604024",
+            case: :lower
+          )
+        )
+
+      y_ge_p =
+        <<0x04>> <> Bitcoinex.Utils.int_to_big(pk.x, 32) <> Bitcoinex.Utils.int_to_big(p, 32)
+
+      assert {:error, _} = Point.parse_public_key(y_ge_p)
+    end
+
+    test "return error for a compressed key with x >= p" do
+      p = Bitcoinex.Secp256k1.Params.curve().p
+      # get_y used to silently reduce x mod p, so 02||(p+1) was accepted as
+      # if it were x = 1; lift_x already rejects x >= p
+      for prefix <- [<<0x02>>, <<0x03>>] do
+        assert {:error, _} =
+                 Point.parse_public_key(prefix <> Bitcoinex.Utils.int_to_big(p + 1, 32))
+      end
+    end
+
+    test "sec round-trips through parse_public_key for compressed and uncompressed keys" do
+      uncompressed =
+        Base.decode16!(
+          "048fdc3d8944cc8d8fe6c666c41a8ed42e60aa399861a756707e127a80b383d178edfbf94dda0487f7910d130f2a37a0647be9335eab5b8d3aa5242445e1604024",
+          case: :lower
+        )
+
+      {:ok, pk} = Point.parse_public_key(uncompressed)
+
+      # uncompressed serialization round-trips
+      rebuilt =
+        <<0x04>> <> Bitcoinex.Utils.int_to_big(pk.x, 32) <> Bitcoinex.Utils.int_to_big(pk.y, 32)
+
+      assert rebuilt == uncompressed
+      assert Point.parse_public_key(rebuilt) == {:ok, pk}
+
+      # compressed serialization round-trips
+      assert pk |> Point.sec() |> Point.parse_public_key() == {:ok, pk}
+    end
   end
 
   describe "sec/1" do

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -1,9 +1,10 @@
 defmodule Bitcoinex.Secp256k1.Secp256k1Test do
   use ExUnit.Case
+  use ExUnitProperties
   doctest Bitcoinex.Secp256k1
 
   alias Bitcoinex.Secp256k1
-  alias Bitcoinex.Secp256k1.{Signature}
+  alias Bitcoinex.Secp256k1.{Params, Signature}
 
   @valid_der_signatures [
     %{
@@ -163,6 +164,69 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
 
         assert sig1 == sig2
       end
+    end
+
+    test "return error on empty, odd-length hex, and undersized inputs without hanging" do
+      # parse_signature used to recurse forever on inputs like "" whose hex
+      # decoding is a no-op, so run each call in a task with a timeout to
+      # keep a regression from hanging the suite.
+      inputs = [<<>>, "", "abc", <<1, 2, 3>>, String.duplicate("zx", 64)]
+
+      for input <- inputs do
+        assert {:error, _} = call_with_timeout(fn -> Signature.parse_signature(input) end)
+      end
+    end
+  end
+
+  describe "serialize_signature/1" do
+    # BIP340 test vector 4: r has ten leading zero bytes, which a minimal
+    # encoding would drop, producing an invalid 53-byte signature.
+    @bip340_vector_4_sig "00000000000000000000003b78ce563f89a0ed9414f5aa28ad0d96d6795f9c6376afb1548af603b3eb45c9f8207dee1060cb71c04e80f593060b07d28308d7f4"
+
+    test "serialize BIP340 test vector 4 signature to exactly 64 bytes" do
+      sig_bytes = Base.decode16!(@bip340_vector_4_sig, case: :lower)
+
+      {:ok, sig} = Signature.parse_signature(sig_bytes)
+      serialized = Signature.serialize_signature(sig)
+
+      assert byte_size(serialized) == 64
+      assert serialized == sig_bytes
+    end
+
+    property "serialization is always 64 bytes and round-trips" do
+      n = Params.curve().n
+
+      # include small values (below 2^248) whose minimal encodings are
+      # shorter than 32 bytes, alongside full-range r/s
+      scalar_gen =
+        StreamData.one_of([
+          StreamData.integer(1..0xFFFFFF),
+          StreamData.map(StreamData.integer(), fn i -> rem(abs(i), n - 1) + 1 end),
+          StreamData.map(StreamData.binary(length: 32), fn b ->
+            rem(:binary.decode_unsigned(b), n - 1) + 1
+          end)
+        ])
+
+      check all(r <- scalar_gen, s <- scalar_gen) do
+        sig = %Signature{r: r, s: s}
+        serialized = Signature.serialize_signature(sig)
+
+        assert byte_size(serialized) == 64
+        assert Signature.parse_signature(serialized) == {:ok, sig}
+      end
+    end
+  end
+
+  defp call_with_timeout(fun) do
+    task = Task.async(fun)
+
+    case Task.yield(task, 5_000) do
+      {:ok, result} ->
+        result
+
+      nil ->
+        Task.shutdown(task, :brutal_kill)
+        flunk("call did not terminate within 5 seconds")
     end
   end
 end

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -242,11 +242,17 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
       assert serialized == sig_bytes
     end
 
-    test "return an error for a scalar wider than 32 bytes" do
+    test "raise for a scalar that is out of range" do
       oversized_scalar = :binary.decode_unsigned(<<1, 0::size(256)>>)
 
-      assert {:error, _} =
-               Signature.serialize_signature(%Signature{r: oversized_scalar, s: 1})
+      for sig <- [
+            %Signature{r: oversized_scalar, s: 1},
+            %Signature{r: 1, s: oversized_scalar},
+            %Signature{r: 0, s: 1},
+            %Signature{r: 1, s: 0}
+          ] do
+        assert_raise ArgumentError, fn -> Signature.serialize_signature(sig) end
+      end
     end
 
     property "serialization is always 64 bytes and round-trips" do

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -190,6 +190,13 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
       assert serialized == sig_bytes
     end
 
+    test "return an error for a scalar wider than 32 bytes" do
+      oversized_scalar = :binary.decode_unsigned(<<1, 0::size(256)>>)
+
+      assert {:error, _} =
+               Signature.serialize_signature(%Signature{r: oversized_scalar, s: 1})
+    end
+
     property "serialization is always 64 bytes and round-trips" do
       n = Params.curve().n
 

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -167,9 +167,7 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
     end
 
     test "return error on empty, odd-length hex, and undersized inputs without hanging" do
-      # parse_signature used to recurse forever on inputs like "" whose hex
-      # decoding is a no-op, so run each call in a task with a timeout to
-      # keep a regression from hanging the suite.
+      # timeout guarded: a regression here hangs forever rather than failing
       inputs = [<<>>, "", "abc", <<1, 2, 3>>, String.duplicate("zx", 64)]
 
       for input <- inputs do
@@ -179,8 +177,7 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
   end
 
   describe "serialize_signature/1" do
-    # BIP340 test vector 4: r has ten leading zero bytes, which a minimal
-    # encoding would drop, producing an invalid 53-byte signature.
+    # BIP340 test vector 4: r has ten leading zero bytes
     @bip340_vector_4_sig "00000000000000000000003b78ce563f89a0ed9414f5aa28ad0d96d6795f9c6376afb1548af603b3eb45c9f8207dee1060cb71c04e80f593060b07d28308d7f4"
 
     test "serialize BIP340 test vector 4 signature to exactly 64 bytes" do
@@ -196,8 +193,7 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
     property "serialization is always 64 bytes and round-trips" do
       n = Params.curve().n
 
-      # include small values (below 2^248) whose minimal encodings are
-      # shorter than 32 bytes, alongside full-range r/s
+      # includes values below 2^248, whose minimal encodings are under 32 bytes
       scalar_gen =
         StreamData.one_of([
           StreamData.integer(1..0xFFFFFF),

--- a/test/secp256k1/secp256k1_test.exs
+++ b/test/secp256k1/secp256k1_test.exs
@@ -127,6 +127,58 @@ defmodule Bitcoinex.Secp256k1.Secp256k1Test do
         assert {:error, _error} = Secp256k1.Signature.der_parse_signature(t.der_signature)
       end
     end
+
+    test "reject DER INTEGERs that are empty, non-minimal, negative, or out of range" do
+      n = Params.curve().n
+
+      cases = [
+        # empty INTEGERs: `30 04 02 00 02 00` decodes to the forbidden (0, 0)
+        {"empty integers", <<0x30, 0x04, 0x02, 0x00, 0x02, 0x00>>},
+        # explicit zero scalars: the (0, 0) forgery encoding
+        {"zero r and s", <<0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x00>>},
+        {"zero r", <<0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x01>>},
+        {"zero s", <<0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x00>>},
+        # unnecessary leading 0x00: a second encoding of r = 1
+        {"non-minimal r", <<0x30, 0x26, 0x02, 0x21, 0x00>> <> <<1::256>> <> <<0x02, 0x01, 0x01>>},
+        {"non-minimal s", <<0x30, 0x26, 0x02, 0x01, 0x01, 0x02, 0x21, 0x00>> <> <<1::256>>},
+        # high bit set: a DER INTEGER whose two's complement value is negative
+        {"negative r", <<0x30, 0x06, 0x02, 0x01, 0x80, 0x02, 0x01, 0x01>>},
+        {"negative s", <<0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x80>>},
+        # scalars must be in [1, n-1]
+        {"r = 2^256", <<0x30, 0x26, 0x02, 0x21, 0x01>> <> <<0::256>> <> <<0x02, 0x01, 0x01>>},
+        {"r = n", <<0x30, 0x26, 0x02, 0x21, 0x00>> <> <<n::256>> <> <<0x02, 0x01, 0x01>>},
+        {"s = n", <<0x30, 0x26, 0x02, 0x01, 0x01, 0x02, 0x21, 0x00>> <> <<n::256>>}
+      ]
+
+      for {label, der} <- cases do
+        assert {:error, _} = Secp256k1.Signature.der_parse_signature(der),
+               "expected #{label} to be rejected"
+      end
+    end
+
+    test "accept the boundary scalars 1 and n-1" do
+      max_scalar = Params.curve().n - 1
+
+      assert {:ok, %Signature{r: 1, s: 1}} ==
+               Secp256k1.Signature.der_parse_signature(
+                 <<0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01>>
+               )
+
+      max_der =
+        <<0x30, 0x46, 0x02, 0x21, 0x00>> <>
+          <<max_scalar::256>> <> <<0x02, 0x21, 0x00>> <> <<max_scalar::256>>
+
+      assert {:ok, %Signature{r: max_scalar, s: max_scalar}} ==
+               Secp256k1.Signature.der_parse_signature(max_der)
+    end
+
+    test "der_serialize_signature emits canonical DER that the strict parser accepts" do
+      for t <- @valid_der_signatures do
+        der = Secp256k1.Signature.der_serialize_signature(t.obj_signature)
+        assert der == t.der_signature
+        assert {:ok, t.obj_signature} == Secp256k1.Signature.der_parse_signature(der)
+      end
+    end
   end
 
   describe "parse_signature/1" do


### PR DESCRIPTION
Security fixes to signature and public key handling, each shipped with a test that fails against the unfixed code.

## Fix 1: `serialize_signature/1` emitted short, invalid signatures (SIG-005)

It used `:binary.encode_unsigned`, which drops leading zero bytes, so any signature whose `r` or `s` has a leading zero byte (~0.8% of real signatures) serialized to fewer than 64 bytes. BIP340 test vector 4 (whose `r` has ten leading zero bytes) re-serialized to **53 bytes**, which the library's own `parse_signature/1` then rejected. `r` and `s` are now each padded to exactly 32 bytes, making `serialize_signature/1` the exact inverse of `parse_signature/1`.

## Fix 2: `parse_signature/1` never terminated on empty input (HIGH)

`Base.decode16("")` returns `{:ok, ""}`, so the hex fallback clause tail-called itself on `""` forever — a silent busy loop reachable from untrusted input. Concretely, **`Invoice.decode("lnbc1qh65qct")` hung a wallet permanently**, since BOLT11 decoding split off an empty signature and fed it to `ecdsa_recover_compact/3`; a slightly longer input like `"lnbc1w4pnfm"` raised a `MatchError` instead. Two layers fixed:

- The hex fallback clause now only accepts 128-character input (a 64-byte compact signature in hex); everything else falls through to `{:error, "invalid signature size"}`.
- `Invoice.decode/1` now checks the data part is at least 111 words (7-word timestamp + 104-word signature) before splitting, returning `{:error, :invoice_data_too_short}`.

The regression tests run each call under a `Task` with a 5s timeout so a regression fails CI instead of hanging it.

## Fix 3: `Address` never checked the 20-byte payload (HIGH)

`Address.encode/3` accepted a hash of any length, and `is_valid?` accepted any payload length behind a valid checksum and version byte. Since `OP_HASH160` always yields 20 bytes, a P2PKH/P2SH output built around any other length can never be spent — passing a SHA-256 or a 33-byte pubkey where a hash160 belongs minted a valid-looking **burn address**. `encode/3` now requires `byte_size(hash) == 20` and validation requires exactly 21 decoded bytes.

## Fix 4: uncompressed public keys were never validated (MEDIUM)

`Point.parse_public_key/1` accepted any 65-byte `04||x||y` input with no field-range or on-curve check — `parse_public_key(<<0x04>> <> <<1::256>> <> <<1::256>>)` returned `{:ok, %Point{x: 1, y: 1}}`, an off-curve point that then flowed into `Math.add`/`Math.multiply` (invalid-curve attack surface) or into unspendable addresses. The uncompressed branch now requires `x < p`, `y < p`, and `y^2 == x^3 + 7 (mod p)`. The compressed branch now rejects `x >= p` (previously `get_y` silently reduced mod p, so `02||(p+1)` was accepted as `x = 1`), matching `Point.lift_x/1`.

Two callers were hardened alongside it:

- `ExtendedKey.check_point/1` hard-matched `{:ok, pubkey} = parse_public_key(key)`. Rejecting `x >= p` newly turned an attacker-supplied xpub into a `MatchError`; it now returns `{:error, "invalid public key"}`.
- The SEC-hex fallback clause called `Base.decode16!/2` on any binary that wasn't 33 or 65 bytes — including 65-byte keys with a bad prefix — so `Script.is_multi?/1` raised `ArgumentError` on attacker script bytes. It is now length-guarded and routed through `Utils.hex_to_bin/1`.

## Fix 5: `der_parse_signature/1` was non-strict (SIG-003)

It enforced only the outer length and the `0x02` markers; `parse_sig_key/1` then did a bare `:binary.decode_unsigned` with no minimal-encoding, zero-value, sign-bit, or `[1, n-1]` check. All five PoC cases were accepted:

```
[A] non-minimal DER (33-byte r with leading 0x00) => {:ok, %Signature{r: 1, s: 1}}
[B] DER with high-bit 'negative' r                => {:ok, %Signature{r: 128, s: 1}}
[C] DER r = 2^256 (> n)                           => accepted
[D] DER (0,0)                                     => parses, and verify_signature => true
[E] DER with empty INTEGERs                       => {:ok, %Signature{r: 0, s: 0}}
```

`[D]` is the `(0,0)` forgery reachable from attacker-serialized bytes; `[A]`/`[B]` are byte-distinct encodings of the same `(r,s)`, i.e. malleability at the encoding layer.

DER INTEGERs are now validated per BIP66 — non-empty, minimally encoded, high bit clear, at most 33 bytes — and both parse paths run the decoded scalars through `Signature.new/2`, which requires `r, s ∈ [1, n-1]`. All five cases now return `{:error, _}`.

## Follow-on: PSBT stores parsed `Signature`s

Because strict DER parsing accepts only canonical encodings and `der_serialize_signature/1` reproduces exactly that encoding, the two are now exact inverses — so the reason `partial_sig` stored raw DER bytes (preserving non-canonical encodings verbatim) no longer applies. `In.partial_sig` now holds a `Signature.t()`, and still round-trips byte-for-byte. `add_field/3` also accepts raw DER and normalizes it; a hand-built struct is revalidated through `Signature.new/2`.

This means a PSBT carrying a non-canonical partial signature is rejected at decode rather than at finalize — earlier than Core, but never rejecting a PSBT Core considers valid overall, since BIP66 has been consensus since 2015.

## API notes

`Address.encode/3`, `Signature.serialize_signature/1` and `der_serialize_signature/1` raise `ArgumentError` on invalid input rather than returning `{:error, _}`, keeping their `String.t()` / `binary` return types. A union return would have been a trap for callers like `Script.to_address/2`, which wraps the result in `{:ok, _}` unconditionally and would have yielded `{:ok, {:error, msg}}`. `Signature.new/2` (formerly the private `new_signature/2`) is now public.

## Coordination note

PR #125 also touches `der_parse_signature/1` and `Ecdsa.verify_signature/3` in this module, adding the same `[1, n-1]` range checks plus the point-at-infinity check in `verify_signature/3`. The two overlap on the range check but not on the DER strictness or the `verify_signature/3` hardening, so both are still needed; whichever lands second needs a small rebase in `lib/secp256k1/secp256k1.ex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
