### PR TITLE
Fix RFC6979 reduction at z == n; add Schnorr.sign/2 with CSPRNG aux (ENT-001, ENT-002)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ bitcoinex-*.tar
 
 # bitcoin related files
 **/*.psbt
+
+# local reference repos (LLM context, not tracked)
+/reference/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Secp256k1.Schnorr.sign/2`, which generates the BIP340 auxiliary randomness from `:crypto.strong_rand_bytes/1` instead of requiring the caller to supply it. `sign/3` is now documented: aux must be either fresh CSPRNG output (randomized signing) or a fixed constant such as 0 (deterministic signing, as the BIP340 test vectors use).
+
 ### Changed
 - Bumped the test-only `excoveralls` dependency to `~> 0.18` (0.15.1 → 0.18.5), which drops the `hackney` HTTP client — `hackney` 1.18.1 carries 6 advisories including EEF-CVE-2026-47071 (HIGH). It was never runtime-reachable (test-only, and CI runs no coverage upload). Pruned the lock entries left unused by the bump (`hackney`, `certifi`, `idna`, `metrics`, `mimerl`, `parse_trans`, `ssl_verify_fun`, `unicode_util_compat`) along with pre-existing stale ones (`combine`, `dialyxir`, `erlex`, `gettext`).
 
 ### Removed
 - The dead `.travis.yml`, which pinned Elixir 1.8 / OTP 21.3 and has been superseded by the GitHub Actions workflow.
+
+### Fixed
+- `Secp256k1.Ecdsa.deterministic_k/2` now reduces the message hash at `z == n`, as RFC 6979 section 2.3.4 (bits2octets) requires — the comparison was `z > n` rather than `z >= n`. Only that single input diverged, and the `k` it produced was still uniform and unpredictable in `[1, n-1]`, so no key or signature was ever at risk; the nonce simply did not match other RFC6979 implementations. Reaching it requires a message hash equal to the curve order.
 
 ## [0.3.0] - 2026-08-04
 ### Added

--- a/lib/extendedkey.ex
+++ b/lib/extendedkey.ex
@@ -266,6 +266,9 @@ defmodule Bitcoinex.ExtendedKey do
       prefix not in @all_prefixes ->
         {:error, "invalid prefix"}
 
+      prefix in @prv_prefixes and not check_private_key(key) ->
+        {:error, "invalid private key"}
+
       # BIP 32 instructs to check that public key is valid upon import
       prefix not in @prv_prefixes and not check_point(key) ->
         {:error, "invalid public key"}
@@ -305,9 +308,21 @@ defmodule Bitcoinex.ExtendedKey do
 
   # verify if point is valid on secp256k1
   defp check_point(key) do
-    {:ok, pubkey} = Point.parse_public_key(key)
-    Bitcoinex.Secp256k1.verify_point(pubkey)
+    case Point.parse_public_key(key) do
+      {:ok, pubkey} -> Bitcoinex.Secp256k1.verify_point(pubkey)
+      {:error, _} -> false
+    end
   end
+
+  defp check_private_key(<<0, key::binary-size(32)>>) do
+    case PrivateKey.new(:binary.decode_unsigned(key)) do
+      {:ok, %PrivateKey{d: 0}} -> false
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
+  defp check_private_key(_), do: false
 
   @doc """
     serialize_extended_key takes an extended key

--- a/lib/secp256k1/ecdsa.ex
+++ b/lib/secp256k1/ecdsa.ex
@@ -65,8 +65,13 @@ defmodule Bitcoinex.Secp256k1.Ecdsa do
     find_candidate(k, v, n)
   end
 
+  # RFC 6979 section 2.3.4 (bits2octets): z2 = z1 - q when z1 >= q, else z1.
+  # The comparison must be >=, not >: at z == n the reduced value is 0, and a
+  # strict > leaves it at n, deriving a k that differs from every other
+  # RFC6979 implementation. One subtraction suffices because z is at most
+  # 2^256 - 1 < 2n.
   defp lower_z(z, n) do
-    if z > n, do: z - n, else: z
+    if z >= n, do: z - n, else: z
   end
 
   @doc """

--- a/lib/secp256k1/schnorr.ex
+++ b/lib/secp256k1/schnorr.ex
@@ -14,6 +14,46 @@ defmodule Bitcoinex.Secp256k1.Schnorr do
     y: Params.curve().g_y
   }
 
+  @doc """
+    sign returns a BIP340 Schnorr signature over the message hash z using
+    privkey and 32 bytes of fresh randomness from the system CSPRNG as the
+    auxiliary randomness.
+
+    This is the recommended entry point. BIP340 mixes the auxiliary randomness
+    into the nonce derivation, which hedges the signature against fault and
+    side-channel attacks that can recover the private key from a purely
+    deterministic nonce. Reach for `sign/3` only when a specific aux value is
+    required, e.g. to reproduce a test vector or to sign deterministically.
+  """
+  @spec sign(PrivateKey.t(), non_neg_integer()) ::
+          {:ok, Signature.t()} | {:error, String.t()}
+  def sign(privkey, z) do
+    aux =
+      32
+      |> :crypto.strong_rand_bytes()
+      |> :binary.decode_unsigned()
+
+    sign(privkey, z, aux)
+  end
+
+  @doc """
+    sign returns a BIP340 Schnorr signature over the message hash z using
+    privkey and the caller-supplied auxiliary randomness aux, an integer
+    serialized as 32 big-endian bytes.
+
+    aux MUST be either
+
+      * 32 bytes of fresh CSPRNG output, for randomized (hedged) signing --
+        prefer `sign/2`, which generates it for you, or
+      * a fixed constant, conventionally 0, for deterministic signing. This is
+        what the BIP340 test vectors use. Deterministic signing is secure, but
+        it gives up the fault- and side-channel-resistance that the synthetic
+        nonce exists to provide.
+
+    Anything in between -- a counter, a timestamp, any low-entropy value --
+    gets you the drawbacks of both. aux is not secret and does not leak the
+    private key, so it is safe to reuse; reusing it only forfeits hedging.
+  """
   @spec sign(PrivateKey.t(), non_neg_integer(), non_neg_integer()) ::
           {:ok, Signature.t()} | {:error, String.t()}
   def sign(privkey, z, aux) do

--- a/scripts/decode_psbt.exs
+++ b/scripts/decode_psbt.exs
@@ -12,10 +12,9 @@ defmodule DecodePSBT do
   @spec run(list(String.t())) :: :ok
   def run(args) do
     psbt_path = List.first(args)
-    hash = calculate_sha256(psbt_path)
     data = decode_psbt(psbt_path)
 
-    print_results(hash, data)
+    print_results(data)
 
     :ok
   end
@@ -23,9 +22,9 @@ defmodule DecodePSBT do
   @doc """
   Print the results to the console.
   """
-  @spec print_results(String.t(), map()) :: :ok
-  def print_results(hash, %{inputs: inputs, outputs: outputs, fee: fee}) do
-    IO.puts("SHA256: #{hash}")
+  @spec print_results(map()) :: :ok
+  def print_results(%{txid: txid, inputs: inputs, outputs: outputs, fee: fee}) do
+    IO.puts("TXID: #{txid}")
 
     IO.puts("\nInputs:")
     Enum.each(inputs, fn input ->
@@ -74,7 +73,10 @@ defmodule DecodePSBT do
 
     fee = sum_values(inputs) - sum_values(outputs)
 
+    {:ok, txid} = PSBT.txid(psbt)
+
     %{
+      txid: txid,
       inputs: inputs,
       outputs: outputs,
       fee: fee
@@ -99,13 +101,6 @@ defmodule DecodePSBT do
 
       {:ok, script} = Script.parse_script(script_pub_key)
       {:ok, address} = Script.to_address(script, :mainnet)
-
-      sighash_type =
-        if sighash_type != nil do
-          Bitcoinex.Utils.little_to_int(sighash_type)
-        else
-          nil
-        end
 
       note =
         if sighash_type != nil and sighash_type != 0x01 do

--- a/test/extendedkey_test.exs
+++ b/test/extendedkey_test.exs
@@ -262,6 +262,30 @@ defmodule Bitcoinex.Secp256k1.ExtendedKeyTest do
       assert ExtendedKey.parse_extended_key(t.xpub_m) == {:ok, t.xpub_m_obj}
       assert ExtendedKey.display_extended_key(t.xpub_m_obj) == t.xpub_m
     end
+
+    test "rejects invalid extended private keys" do
+      t = @bip32_test_case_1
+
+      for key <- [<<0::size(264)>>, <<1, 0::size(256)>>] do
+        invalid_xprv =
+          t.xprv_m_obj
+          |> Map.put(:key, key)
+          |> ExtendedKey.display_extended_key()
+
+        assert {:error, "invalid private key"} = ExtendedKey.parse_extended_key(invalid_xprv)
+      end
+    end
+
+    test "rejects invalid extended public keys" do
+      t = @bip32_test_case_1
+
+      invalid_xpub =
+        t.xpub_m_obj
+        |> Map.put(:key, <<4, 0::size(256)>>)
+        |> ExtendedKey.display_extended_key()
+
+      assert {:error, "invalid public key"} = ExtendedKey.parse_extended_key(invalid_xpub)
+    end
   end
 
   describe "to_extended_public_key/1" do

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -1,9 +1,67 @@
+defmodule Bitcoinex.Secp256k1.Rfc6979Reference do
+  @moduledoc false
+  # An independent implementation of RFC 6979 section 3.2, transcribed directly
+  # from the RFC and specialized to secp256k1 + SHA-256 (so qlen == hlen == 256
+  # and bits2int is the identity on a 32-byte hash). It shares no code with
+  # Bitcoinex.Secp256k1.Ecdsa, so it can be used to cross-check
+  # deterministic_k/2 rather than merely restating it.
+  #
+  # The one deliberate omission is the "r != 0" half of step h.3: the RFC allows
+  # rejecting a candidate that produces r == 0, which Ecdsa.deterministic_k/2
+  # does. No known input reaches it, and finding one would mean finding a
+  # multiple of n on the x-axis of the curve.
+
+  @n Bitcoinex.Secp256k1.Params.curve().n
+
+  @spec deterministic_k(pos_integer(), non_neg_integer()) :: pos_integer()
+  def deterministic_k(d, h1) do
+    # 2.3.4 bits2octets: z1 = bits2int(h1), z2 = z1 - q if z1 >= q else z1
+    z2 = if h1 >= @n, do: h1 - @n, else: h1
+    m = int2octets(d) <> int2octets(z2)
+    # 3.2(b) V = 0x01 repeated hlen/8 times
+    v = :binary.copy(<<0x01>>, 32)
+    # 3.2(c) K = 0x00 repeated hlen/8 times
+    k = :binary.copy(<<0x00>>, 32)
+    # 3.2(d) K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1))
+    k = hmac(k, v <> <<0x00>> <> m)
+    # 3.2(e) V = HMAC_K(V)
+    v = hmac(k, v)
+    # 3.2(f) K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1))
+    k = hmac(k, v <> <<0x01>> <> m)
+    # 3.2(g) V = HMAC_K(V)
+    v = hmac(k, v)
+    # 3.2(h)
+    generate(k, v)
+  end
+
+  # 3.2(h): T = HMAC_K(V) (a single iteration, since hlen == qlen); accept
+  # bits2int(T) if it lands in [1, q-1], otherwise reseed and retry.
+  defp generate(k, v) do
+    t = hmac(k, v)
+    candidate = :binary.decode_unsigned(t)
+
+    if candidate >= 1 and candidate < @n do
+      candidate
+    else
+      k = hmac(k, t <> <<0x00>>)
+      generate(k, hmac(k, t))
+    end
+  end
+
+  # 2.3.3 int2octets, with rlen == 256 bits
+  defp int2octets(i), do: <<i::unsigned-big-integer-size(256)>>
+
+  defp hmac(k, data), do: :crypto.mac(:hmac, :sha256, k, data)
+end
+
 defmodule Bitcoinex.Secp256k1.EcdsaTest do
   use ExUnit.Case
 
   doctest Bitcoinex.Secp256k1.Ecdsa
 
-  alias Bitcoinex.Secp256k1.{Ecdsa, Point, PrivateKey, Signature}
+  alias Bitcoinex.Secp256k1.{Ecdsa, Params, Point, PrivateKey, Rfc6979Reference, Signature}
+
+  @n Params.curve().n
 
   @valid_signatures_for_public_key_recovery [
     %{
@@ -144,6 +202,33 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     }
   ]
 
+  # Boundary values of z, in particular the ones around the bits2octets
+  # reduction at z == n. A 32-byte hash can take any of these values.
+  @z_boundaries [
+    0,
+    1,
+    @n - 1,
+    @n,
+    @n + 1,
+    @n + 12_345,
+    Bitwise.bsl(1, 256) - 1
+  ]
+
+  defp random_secret do
+    d =
+      32
+      |> :crypto.strong_rand_bytes()
+      |> :binary.decode_unsigned()
+
+    if d >= 1 and d < @n, do: d, else: random_secret()
+  end
+
+  defp random_z do
+    32
+    |> :crypto.strong_rand_bytes()
+    |> :binary.decode_unsigned()
+  end
+
   describe "test deterministic k calculation" do
     test "successfully derive correct k value" do
       for t <- @rfc6979_test_cases do
@@ -151,6 +236,125 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
         z = :binary.decode_unsigned(:crypto.hash(:sha256, t.m))
         assert Ecdsa.deterministic_k(p, z) == %PrivateKey{d: t.k}
       end
+    end
+
+    test "matches an independent from-spec RFC6979 implementation at boundary values of z" do
+      for t <- @rfc6979_test_cases, z <- @z_boundaries do
+        assert Ecdsa.deterministic_k(%PrivateKey{d: t.d}, z) == %PrivateKey{
+                 d: Rfc6979Reference.deterministic_k(t.d, z)
+               },
+               "deterministic_k diverged from the RFC at d=#{t.d}, z=#{z}"
+      end
+    end
+
+    test "matches an independent from-spec RFC6979 implementation on random inputs" do
+      for _ <- 1..200 do
+        d = random_secret()
+
+        # half the cases draw z uniformly from [0, 2^256), which lands above n
+        # only with negligible probability; the other half force z >= n so the
+        # bits2octets reduction is actually exercised.
+        z =
+          case rem(random_z(), 2) do
+            0 -> random_z()
+            1 -> @n + rem(random_z(), Bitwise.bsl(1, 256) - @n)
+          end
+
+        assert Ecdsa.deterministic_k(%PrivateKey{d: d}, z) == %PrivateKey{
+                 d: Rfc6979Reference.deterministic_k(d, z)
+               },
+               "deterministic_k diverged from the RFC at d=#{d}, z=#{z}"
+      end
+    end
+
+    test "reduces z by n exactly as bits2octets does, so k(n + x) == k(x)" do
+      # RFC 6979 2.3.4 subtracts q from z when z >= q. z == n (x == 0) is the
+      # only input where a strict > comparison differs, and it is the case a
+      # naive implementation gets wrong.
+      for t <- @rfc6979_test_cases, x <- [0, 1, 2, 12_345, Bitwise.bsl(1, 128)] do
+        p = %PrivateKey{d: t.d}
+        assert Ecdsa.deterministic_k(p, @n + x) == Ecdsa.deterministic_k(p, x)
+      end
+    end
+
+    test "always returns a k in [1, n-1]" do
+      for _ <- 1..100 do
+        %PrivateKey{d: k} = Ecdsa.deterministic_k(%PrivateKey{d: random_secret()}, random_z())
+        assert k >= 1 and k < @n
+      end
+
+      for t <- @rfc6979_test_cases, z <- @z_boundaries do
+        %PrivateKey{d: k} = Ecdsa.deterministic_k(%PrivateKey{d: t.d}, z)
+        assert k >= 1 and k < @n
+      end
+    end
+
+    test "k depends on both the private key and the message hash" do
+      z = random_z()
+      d1 = random_secret()
+      d2 = random_secret()
+
+      k1 = Ecdsa.deterministic_k(%PrivateKey{d: d1}, z)
+      # same inputs, same k
+      assert k1 == Ecdsa.deterministic_k(%PrivateKey{d: d1}, z)
+      # different key, different k
+      assert k1 != Ecdsa.deterministic_k(%PrivateKey{d: d2}, z)
+      # different message, different k
+      assert k1 != Ecdsa.deterministic_k(%PrivateKey{d: d1}, z + 1)
+    end
+  end
+
+  describe "interoperability with OpenSSL (:crypto)" do
+    test "signatures produced by sign/2 verify under :crypto" do
+      for _ <- 1..50 do
+        privkey = %PrivateKey{d: random_secret()}
+        pubkey = PrivateKey.to_point(privkey)
+
+        digest = :crypto.strong_rand_bytes(32)
+        z = :binary.decode_unsigned(digest)
+
+        der =
+          privkey
+          |> Ecdsa.sign(z)
+          |> Signature.der_serialize_signature()
+
+        pubkey_bytes = pubkey |> Point.serialize_public_key() |> Base.decode16!(case: :lower)
+
+        assert :crypto.verify(:ecdsa, :sha256, {:digest, digest}, der, [
+                 pubkey_bytes,
+                 :secp256k1
+               ])
+      end
+    end
+
+    test "signatures produced by :crypto verify under verify_signature/3" do
+      for _ <- 1..50 do
+        d = random_secret()
+        privkey = %PrivateKey{d: d}
+        pubkey = PrivateKey.to_point(privkey)
+
+        digest = :crypto.strong_rand_bytes(32)
+        z = :binary.decode_unsigned(digest)
+        secret_bytes = Bitcoinex.Utils.pad(:binary.encode_unsigned(d), 32, :leading)
+
+        der = :crypto.sign(:ecdsa, :sha256, {:digest, digest}, [secret_bytes, :secp256k1])
+
+        assert {:ok, sig} = Signature.der_parse_signature(der)
+        assert Ecdsa.verify_signature(pubkey, z, sig)
+      end
+    end
+
+    test "verify_signature/3 rejects a signature over a different message" do
+      privkey = %PrivateKey{d: random_secret()}
+      pubkey = PrivateKey.to_point(privkey)
+      z = random_z()
+      sig = Ecdsa.sign(privkey, z)
+
+      assert Ecdsa.verify_signature(pubkey, z, sig)
+      refute Ecdsa.verify_signature(pubkey, z - 1, sig)
+      refute Ecdsa.verify_signature(pubkey, z, %Signature{sig | r: sig.r + 1})
+      refute Ecdsa.verify_signature(pubkey, z, %Signature{sig | s: sig.s + 1})
+      refute Ecdsa.verify_signature(PrivateKey.to_point(%PrivateKey{d: random_secret()}), z, sig)
     end
   end
 

--- a/test/secp256k1/ecdsa_test.exs
+++ b/test/secp256k1/ecdsa_test.exs
@@ -1,65 +1,9 @@
-defmodule Bitcoinex.Secp256k1.Rfc6979Reference do
-  @moduledoc false
-  # An independent implementation of RFC 6979 section 3.2, transcribed directly
-  # from the RFC and specialized to secp256k1 + SHA-256 (so qlen == hlen == 256
-  # and bits2int is the identity on a 32-byte hash). It shares no code with
-  # Bitcoinex.Secp256k1.Ecdsa, so it can be used to cross-check
-  # deterministic_k/2 rather than merely restating it.
-  #
-  # The one deliberate omission is the "r != 0" half of step h.3: the RFC allows
-  # rejecting a candidate that produces r == 0, which Ecdsa.deterministic_k/2
-  # does. No known input reaches it, and finding one would mean finding a
-  # multiple of n on the x-axis of the curve.
-
-  @n Bitcoinex.Secp256k1.Params.curve().n
-
-  @spec deterministic_k(pos_integer(), non_neg_integer()) :: pos_integer()
-  def deterministic_k(d, h1) do
-    # 2.3.4 bits2octets: z1 = bits2int(h1), z2 = z1 - q if z1 >= q else z1
-    z2 = if h1 >= @n, do: h1 - @n, else: h1
-    m = int2octets(d) <> int2octets(z2)
-    # 3.2(b) V = 0x01 repeated hlen/8 times
-    v = :binary.copy(<<0x01>>, 32)
-    # 3.2(c) K = 0x00 repeated hlen/8 times
-    k = :binary.copy(<<0x00>>, 32)
-    # 3.2(d) K = HMAC_K(V || 0x00 || int2octets(x) || bits2octets(h1))
-    k = hmac(k, v <> <<0x00>> <> m)
-    # 3.2(e) V = HMAC_K(V)
-    v = hmac(k, v)
-    # 3.2(f) K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1))
-    k = hmac(k, v <> <<0x01>> <> m)
-    # 3.2(g) V = HMAC_K(V)
-    v = hmac(k, v)
-    # 3.2(h)
-    generate(k, v)
-  end
-
-  # 3.2(h): T = HMAC_K(V) (a single iteration, since hlen == qlen); accept
-  # bits2int(T) if it lands in [1, q-1], otherwise reseed and retry.
-  defp generate(k, v) do
-    t = hmac(k, v)
-    candidate = :binary.decode_unsigned(t)
-
-    if candidate >= 1 and candidate < @n do
-      candidate
-    else
-      k = hmac(k, t <> <<0x00>>)
-      generate(k, hmac(k, t))
-    end
-  end
-
-  # 2.3.3 int2octets, with rlen == 256 bits
-  defp int2octets(i), do: <<i::unsigned-big-integer-size(256)>>
-
-  defp hmac(k, data), do: :crypto.mac(:hmac, :sha256, k, data)
-end
-
 defmodule Bitcoinex.Secp256k1.EcdsaTest do
   use ExUnit.Case
 
   doctest Bitcoinex.Secp256k1.Ecdsa
 
-  alias Bitcoinex.Secp256k1.{Ecdsa, Params, Point, PrivateKey, Rfc6979Reference, Signature}
+  alias Bitcoinex.Secp256k1.{Ecdsa, Params, Point, PrivateKey, Signature}
 
   @n Params.curve().n
 
@@ -202,6 +146,132 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     }
   ]
 
+  # No published RFC6979 vector exercises z >= n, because no message hashes to
+  # a value that large in practice. These were generated with python-ecdsa
+  # 0.19.2, an independent implementation, which reproduces all of
+  # @rfc6979_test_cases above exactly:
+  #
+  #     from ecdsa import rfc6979
+  #     import hashlib
+  #     n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+  #     rfc6979.generate_k(n, d, hashlib.sha256, z.to_bytes(32, "big"))
+  #
+  # Note that (d: 1, z: n) and (d: 1, z: 0) below share a k: that is the
+  # bits2octets reduction, confirmed by an implementation that is not ours.
+  @rfc6979_reduction_test_cases [
+    %{
+      # z == n, the input a strict > comparison gets wrong
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,
+      k: 0x010497D369B3D525CA15EC29C104A694210BB59FF6CABFC10AFE6DF0283896DF
+    },
+    %{
+      # z == 0, the value z == n reduces to
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0x0000000000000000000000000000000000000000000000000000000000000000,
+      k: 0x010497D369B3D525CA15EC29C104A694210BB59FF6CABFC10AFE6DF0283896DF
+    },
+    %{
+      # z == n + 1
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364142,
+      k: 0x9A409DAB05968059DA3EFB323DC67C96F234571B965FD39810CA0643FBB795AC
+    },
+    %{
+      # z == n
+      d: 0xF8B8AF8CE3C7CCA5E300D33939540C10D45CE001B8F252BFBC57BA0342904181,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,
+      k: 0xFE5C2172613635E945784D70D7CBFDEF33719A5B661711DB2D684A7799DE32DF
+    },
+    %{
+      # z == 2^256 - 1, the largest a 32-byte hash can be
+      d: 0xF8B8AF8CE3C7CCA5E300D33939540C10D45CE001B8F252BFBC57BA0342904181,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+      k: 0xAF12E23175D8C6A77C6FA469C454870A6E7229D07F8E6E206189DB60985C948E
+    },
+    %{
+      # z == n + 12345
+      d: 0xE91671C46231F833A6406CCBEA0E3E392C76C167BAC1CB013F6F1013980455C2,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD036717A,
+      k: 0xD8F60463AC4719152E20A3C3031E2DD42E9D6BE6B0BA0B1C117DC6F701B4C75A
+    },
+    %{
+      # z == n
+      d: 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,
+      k: 0x604ADEA240A4FE28A8A8D87DE7C70FEA679A252C796EC76196AA53C1BB4D79E6
+    },
+    %{
+      # z == n + 1, with d == n - 1
+      d: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364142,
+      k: 0x8B019446AA53C1E9EC19B87CC6229A79954DEB5AC752E13D874EA6911DA70CE5
+    }
+  ]
+
+  # Deterministic signatures from libsecp256k1 (via coincurve 21.0.0), the
+  # implementation Bitcoin Core signs with. Unlike the k-only vectors above,
+  # these pin the whole signing path end to end: RFC6979 nonce derivation, the
+  # r/s computation, low-s normalization, and DER encoding.
+  #
+  #     from coincurve import PrivateKey
+  #     PrivateKey(d.to_bytes(32, "big")).sign(z.to_bytes(32, "big"), hasher=None).hex()
+  #
+  # The z == n and z == 2^256 - 1 cases are worth noting: libsecp256k1 reduces
+  # the message the same way RFC6979 bits2octets does, so its signature at
+  # z == n is byte-for-byte the one it produces at z == 0.
+  @libsecp256k1_signature_test_cases [
+    %{
+      # sha256("Satoshi Nakamoto")
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0xA0DC65FFCA799873CBEA0AC274015B9526505DAAAED385155425F7337704883E,
+      der:
+        "3045022100934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d802202442ce9d2b916064108014783e923ec36b49743e2ffa1c4496f01a512aafd9e5"
+    },
+    %{
+      # sha256("Alan Turing")
+      d: 0xF8B8AF8CE3C7CCA5E300D33939540C10D45CE001B8F252BFBC57BA0342904181,
+      z: 0x4BA38D48A60F1B29E9EB726EAFF08B2E83D8D81E031666FEE50E85900D7DC1EF,
+      der:
+        "304402207063ae83e7f62bbb171798131b4a0564b956930092b33b07b395615d9ec7e15c022058dfcc1e00a35e1572f366ffe34ba0fc47db1e7189759b9fb233c5b05ab388ea"
+    },
+    %{
+      # double_sha256("hello world")
+      d: 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF,
+      z: 0xBC62D4B80D9E36DA29C16C5D4D9F11731F36052C72401A76C23C0FB5A9B74423,
+      der:
+        "3044022008b772f5016f3d4d7ee74e8abd864e74a2ce1737695b77c82b5ef41967820f0d02206133f649c1719feb414f2d7389649ca303be5fc18cfb20de36cdeb5bb17c30a1"
+    },
+    %{
+      # z == 0
+      d: 0xE91671C46231F833A6406CCBEA0E3E392C76C167BAC1CB013F6F1013980455C2,
+      z: 0x0000000000000000000000000000000000000000000000000000000000000000,
+      der:
+        "3045022100a16a97c44ac41c22edc3773fbac1298e2e87d0bff3c1d14cdc27adc9ab5ee57e02202badd4686a4d8f9bf506c5505a2a6afb1feb801f0f970e114eccaccb23764dce"
+    },
+    %{
+      # sha256("bitcoinex"), d == n - 1
+      d: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140,
+      z: 0x32A95CD4352F083547FAFC9659E3E570D471DF8EB4C98BBFD3F176684BD42C02,
+      der:
+        "304402204f1bddc63916162929b7060bf0bc368fba7524e33c00828a49dd26ef7f15985f0220172060464c2796e715ebd23c6b06a360231630efcd55ec46b2242f5ec1608b02"
+    },
+    %{
+      # z == n, which libsecp256k1 reduces to 0 exactly as bits2octets does
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,
+      der:
+        "3045022100a0b37f8fba683cc68f6574cd43b39f0343a50008bf6ccea9d13231d9e7e2e1e4022011edc8d307254296264aebfc3dc76cd8b668373a072fd64665b50000e9fcce52"
+    },
+    %{
+      # z == 2^256 - 1, above n
+      d: 0x0000000000000000000000000000000000000000000000000000000000000001,
+      z: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF,
+      der:
+        "304402207cb38cc5712e9e11a767615f6080dbc111c9cdd613eb98999fd92a86bafd454002207923ca1f4d03471d2866f776ef8a6d3cac099b427331aeb245aa9dafeddcf115"
+    }
+  ]
+
   # Boundary values of z, in particular the ones around the bits2octets
   # reduction at z == n. A 32-byte hash can take any of these values.
   @z_boundaries [
@@ -214,19 +284,15 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     Bitwise.bsl(1, 256) - 1
   ]
 
-  defp random_secret do
-    d =
-      32
-      |> :crypto.strong_rand_bytes()
-      |> :binary.decode_unsigned()
-
-    if d >= 1 and d < @n, do: d, else: random_secret()
-  end
-
   defp random_z do
     32
     |> :crypto.strong_rand_bytes()
     |> :binary.decode_unsigned()
+  end
+
+  defp random_secret do
+    d = random_z()
+    if d >= 1 and d < @n, do: d, else: random_secret()
   end
 
   describe "test deterministic k calculation" do
@@ -238,32 +304,10 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
       end
     end
 
-    test "matches an independent from-spec RFC6979 implementation at boundary values of z" do
-      for t <- @rfc6979_test_cases, z <- @z_boundaries do
-        assert Ecdsa.deterministic_k(%PrivateKey{d: t.d}, z) == %PrivateKey{
-                 d: Rfc6979Reference.deterministic_k(t.d, z)
-               },
-               "deterministic_k diverged from the RFC at d=#{t.d}, z=#{z}"
-      end
-    end
-
-    test "matches an independent from-spec RFC6979 implementation on random inputs" do
-      for _ <- 1..200 do
-        d = random_secret()
-
-        # half the cases draw z uniformly from [0, 2^256), which lands above n
-        # only with negligible probability; the other half force z >= n so the
-        # bits2octets reduction is actually exercised.
-        z =
-          case rem(random_z(), 2) do
-            0 -> random_z()
-            1 -> @n + rem(random_z(), Bitwise.bsl(1, 256) - @n)
-          end
-
-        assert Ecdsa.deterministic_k(%PrivateKey{d: d}, z) == %PrivateKey{
-                 d: Rfc6979Reference.deterministic_k(d, z)
-               },
-               "deterministic_k diverged from the RFC at d=#{d}, z=#{z}"
+    test "matches python-ecdsa at and above the bits2octets reduction boundary" do
+      for t <- @rfc6979_reduction_test_cases do
+        assert Ecdsa.deterministic_k(%PrivateKey{d: t.d}, t.z) == %PrivateKey{d: t.k},
+               "deterministic_k diverged from python-ecdsa at d=0x#{Integer.to_string(t.d, 16)}, z=0x#{Integer.to_string(t.z, 16)}"
       end
     end
 
@@ -304,9 +348,24 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     end
   end
 
+  describe "interoperability with libsecp256k1" do
+    test "sign/2 reproduces libsecp256k1's deterministic signatures byte for byte" do
+      for t <- @libsecp256k1_signature_test_cases do
+        der =
+          %PrivateKey{d: t.d}
+          |> Ecdsa.sign(t.z)
+          |> Signature.der_serialize_signature()
+          |> Base.encode16(case: :lower)
+
+        assert der == t.der,
+               "diverged from libsecp256k1 at d=0x#{Integer.to_string(t.d, 16)}, z=0x#{Integer.to_string(t.z, 16)}"
+      end
+    end
+  end
+
   describe "interoperability with OpenSSL (:crypto)" do
     test "signatures produced by sign/2 verify under :crypto" do
-      for _ <- 1..50 do
+      for _ <- 1..1000 do
         privkey = %PrivateKey{d: random_secret()}
         pubkey = PrivateKey.to_point(privkey)
 
@@ -328,7 +387,7 @@ defmodule Bitcoinex.Secp256k1.EcdsaTest do
     end
 
     test "signatures produced by :crypto verify under verify_signature/3" do
-      for _ <- 1..50 do
+      for _ <- 1..1000 do
         d = random_secret()
         privkey = %PrivateKey{d: d}
         pubkey = PrivateKey.to_point(privkey)

--- a/test/secp256k1/schnorr_test.exs
+++ b/test/secp256k1/schnorr_test.exs
@@ -153,6 +153,21 @@ defmodule Bitcoinex.Secp256k1.SchnorrTest do
                                      }
                                    ]
 
+  defp random_secret do
+    d =
+      32
+      |> :crypto.strong_rand_bytes()
+      |> :binary.decode_unsigned()
+
+    if d >= 1 and d < Secp256k1.Params.curve().n, do: d, else: random_secret()
+  end
+
+  defp random_z do
+    32
+    |> :crypto.strong_rand_bytes()
+    |> :binary.decode_unsigned()
+  end
+
   describe "sign/3" do
     test "sign" do
       for t <- @schnorr_signatures_with_secrets do
@@ -176,7 +191,95 @@ defmodule Bitcoinex.Secp256k1.SchnorrTest do
     end
   end
 
+  describe "sign/2" do
+    test "produces a valid signature for random keys and messages" do
+      for _ <- 1..100 do
+        {:ok, sk} = PrivateKey.new(random_secret())
+        pubkey = sk |> Secp256k1.force_even_y() |> PrivateKey.to_point()
+        z = random_z()
+
+        assert {:ok, sig} = Schnorr.sign(sk, z)
+        assert Schnorr.verify_signature(pubkey, z, sig)
+        assert sig.r < Secp256k1.Params.curve().p
+        assert sig.s < Secp256k1.Params.curve().n
+      end
+    end
+
+    test "draws fresh aux randomness on every call, so repeated signatures differ" do
+      {:ok, sk} = PrivateKey.new(random_secret())
+      pubkey = sk |> Secp256k1.force_even_y() |> PrivateKey.to_point()
+      z = random_z()
+
+      sigs =
+        for _ <- 1..50 do
+          assert {:ok, sig} = Schnorr.sign(sk, z)
+          assert Schnorr.verify_signature(pubkey, z, sig)
+          sig
+        end
+
+      # Every nonce is drawn from 256 bits of CSPRNG output; a collision here
+      # means sign/2 is not randomizing at all.
+      assert sigs |> Enum.uniq() |> length() == 50
+    end
+
+    test "rejects an invalid private key" do
+      assert {:error, _} = Schnorr.sign(%PrivateKey{d: 0}, random_z())
+      assert {:error, _} = Schnorr.sign(%PrivateKey{d: Secp256k1.Params.curve().n}, random_z())
+    end
+  end
+
+  describe "sign/3 aux randomness" do
+    setup do
+      {:ok, sk} = PrivateKey.new(random_secret())
+      pubkey = sk |> Secp256k1.force_even_y() |> PrivateKey.to_point()
+      {:ok, privkey: sk, pubkey: pubkey, z: random_z()}
+    end
+
+    test "is deterministic for a fixed aux", %{privkey: sk, z: z} do
+      # BIP340 permits deterministic signing with a constant aux, and the
+      # official test vectors rely on it. Signing twice with the same aux must
+      # give bit-identical signatures.
+      for aux <- [0, 1, random_z()] do
+        assert {:ok, sig1} = Schnorr.sign(sk, z, aux)
+        assert {:ok, sig2} = Schnorr.sign(sk, z, aux)
+        assert sig1 == sig2
+      end
+    end
+
+    test "changes the nonce when aux changes", %{privkey: sk, pubkey: pubkey, z: z} do
+      assert {:ok, sig1} = Schnorr.sign(sk, z, 0)
+      assert {:ok, sig2} = Schnorr.sign(sk, z, 1)
+
+      assert sig1.r != sig2.r
+      assert sig1.s != sig2.s
+      assert Schnorr.verify_signature(pubkey, z, sig1)
+      assert Schnorr.verify_signature(pubkey, z, sig2)
+    end
+
+    test "changes the nonce when the message changes, at a fixed aux", %{privkey: sk, z: z} do
+      assert {:ok, sig1} = Schnorr.sign(sk, z, 0)
+      assert {:ok, sig2} = Schnorr.sign(sk, z + 1, 0)
+      assert sig1.r != sig2.r
+    end
+  end
+
   describe "verify_signature/3" do
+    test "rejects a signature over a different message or from a different key" do
+      {:ok, sk} = PrivateKey.new(random_secret())
+      pubkey = sk |> Secp256k1.force_even_y() |> PrivateKey.to_point()
+      z = random_z()
+
+      assert {:ok, sig} = Schnorr.sign(sk, z)
+      assert Schnorr.verify_signature(pubkey, z, sig)
+
+      refute Schnorr.verify_signature(pubkey, z - 1, sig)
+      refute Schnorr.verify_signature(pubkey, z, %Signature{sig | s: sig.s - 1})
+
+      {:ok, other} = PrivateKey.new(random_secret())
+      other_pubkey = other |> Secp256k1.force_even_y() |> PrivateKey.to_point()
+      refute Schnorr.verify_signature(other_pubkey, z, sig)
+    end
+
     test "verify_signature" do
       for t <- @schnorr_signatures_no_secrets do
         pk_res =

--- a/test/secp256k1/schnorr_test.exs
+++ b/test/secp256k1/schnorr_test.exs
@@ -153,19 +153,15 @@ defmodule Bitcoinex.Secp256k1.SchnorrTest do
                                      }
                                    ]
 
-  defp random_secret do
-    d =
-      32
-      |> :crypto.strong_rand_bytes()
-      |> :binary.decode_unsigned()
-
-    if d >= 1 and d < Secp256k1.Params.curve().n, do: d, else: random_secret()
-  end
-
   defp random_z do
     32
     |> :crypto.strong_rand_bytes()
     |> :binary.decode_unsigned()
+  end
+
+  defp random_secret do
+    d = random_z()
+    if d >= 1 and d < Secp256k1.Params.curve().n, do: d, else: random_secret()
   end
 
   describe "sign/3" do


### PR DESCRIPTION
Two nonce-generation findings, both informational — neither risks keys or funds — plus input validation on extended-key import and cross-library test coverage for the signature paths.

## ENT-001 — RFC6979 `bits2octets` at `z == n`

`lower_z/2` tested `z > n`, but [RFC 6979 §2.3.4](https://tools.ietf.org/html/rfc6979#section-2.3.4) reduces when `z1 >= q`. Only the single input `z == n` diverged.

```diff
-    if z > n, do: z - n, else: z
+    if z >= n, do: z - n, else: z
```

**Impact: interop only.** The `k` derived at that input is still uniform and unpredictable in `[1, n-1]` — no bias, no reuse, no key-recovery path. It just isn't the `k` any other RFC6979 implementation would pick. Reaching it requires a SHA-256 preimage that hashes to exactly the curve order.

## ENT-002 — `Schnorr.sign/3` demanded aux with no default and no docs

`sign/3` was the only signing entry point, and the library had no RNG call site anywhere in `lib/`. A caller who assumed nonces were randomized internally silently got BIP340's deterministic mode — secure, but without the synthetic-nonce hedging against fault and side-channel attacks.

Adds `Schnorr.sign/2`, which draws 32 bytes from `:crypto.strong_rand_bytes/1`, and documents on `sign/3` that aux must be either fresh CSPRNG output or a fixed constant (conventionally 0, as the BIP340 vectors use) — never something in between.

## Also included

Two fixes found alongside the above, in code the new tests exercise:

- **`ExtendedKey.parse_extended_key/1` now validates private keys on import** (`lib/extendedkey.ex`). It already checked that an imported public key was a valid curve point, per BIP32, but accepted any 33 bytes for an `xprv` — including a zero key or one at/above the curve order. It also raised `MatchError` rather than returning `{:error, _}` when the public key failed to parse at all; that path now returns `{:error, "invalid public key"}`. **Behavior change:** malformed extended keys that previously parsed (or crashed) now return `{:error, "invalid private key"}` / `{:error, "invalid public key"}`.
- **`scripts/decode_psbt.exs`** — prints the unsigned tx's TXID instead of the PSBT file's SHA256, and drops a `little_to_int/1` call on `sighash_type`, which `PSBT.In` has parsed to an integer since the PSBT v0 work. Without that, every input was flagged `NON-STANDARD SIGHASH TYPE / UNKNOWN`.

## Testing

No published RFC6979 vector exercises `z >= n`, since no message hashes that large in practice. Rather than reimplement the RFC in the test suite — which would only restate my own reading of it — the gap is closed with hardcoded vectors from two implementations that aren't ours:

- **python-ecdsa 0.19.2** for the nonce, at `z ∈ {0, n, n+1, n+12345, 2^256-1}` across several keys. Its `bits2octets` is `z2 = z1 - order; if z2 < 0: z2 = z1`, independently confirming the `>=` semantics, and it reproduces all 5 existing bitcointalk vectors exactly.
- **libsecp256k1** (via coincurve), the implementation Bitcoin Core signs with, for 7 full deterministic DER signatures. These pin the *entire* signing path rather than just the nonce — RFC6979 derivation, the r/s computation, low-s normalization, DER encoding. libsecp256k1 emits the same signature at `z == n` as at `z == 0`, corroborating the reduction from a third source.

Each vector table carries the snippet that regenerates it. Alongside those:

- **`k(n + x) == k(x)`** — the bits2octets invariant, derived from the spec text rather than reimplementing it. `x == 0` is the case that was broken.
- **ECDSA interop with OpenSSL both directions**, 1000 iterations each: signatures from `sign/2` verify under `:crypto.verify`, and `:crypto` signatures verify under `verify_signature/3`.
- `k` always lands in `[1, n-1]`, and depends on both the key and the message.
- Schnorr `sign/2` produces valid, verifiable, never-repeating signatures; `sign/3` stays bit-identical for a fixed aux and changes its nonce when either aux or the message changes.
- `verify_signature/3` rejects tampered `r`/`s`, wrong message, wrong key — both schemes.
- `parse_extended_key/1` rejects a zero private key, a private key with a non-zero pad byte, and an unparseable public key.

Three tests fail against the old `z > n` comparison (verified by reverting the one-character fix): the python-ecdsa vectors, the libsecp256k1 vectors, and the `k(n + x) == k(x)` invariant. Full suite: 354 tests, 0 failures; `mix lint.all` clean.

## Known gap, not addressed here

`ExtendedKey.derive_private_child/2` serializes the child scalar with a bare `:binary.encode_unsigned/1` and no left-pad to 32 bytes, so roughly 1 in 256 derivations produces a short key that `parse_extended_key/1` then rejects with `{:error, "error parsing key"}` (e.g. child index 581 from a `<<0x42>>`-repeated seed). Pre-existing on `master` and left for a follow-up, since fixing it means touching derivation rather than import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
